### PR TITLE
404、500画面の作成

### DIFF
--- a/frontend/src/app/components/ErrorMessage.tsx
+++ b/frontend/src/app/components/ErrorMessage.tsx
@@ -1,0 +1,29 @@
+import { Box, Typography } from '@mui/material'
+
+type ErrorMessageProps = {
+  errorCode: string
+  errorMessage: React.ReactNode
+}
+
+const ErrorMessage = ({ errorCode, errorMessage }: ErrorMessageProps) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        textAlign: 'center',
+        height: 'calc(100vh - 64px)',
+        maxWidth: '70%',
+        margin: '0 auto',
+      }}
+    >
+      <Typography variant="h4" sx={{ color: '#1E90FF', mb: 1 }}>
+        {errorCode}
+      </Typography>
+      <Typography variant="body2">{errorMessage}</Typography>
+    </Box>
+  )
+}
+
+export default ErrorMessage

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,29 +1,20 @@
 'use client'
 
-import { Typography, Box } from '@mui/material'
+import ErrorMessage from './components/ErrorMessage'
 
 const Error = () => {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        textAlign: 'center',
-        height: 'calc(100vh - 64px)',
-        maxWidth: '70%',
-        margin: '0 auto',
-      }}
-    >
-      <Typography variant="h4" sx={{ color: '#1E90FF', mb: 1 }}>
-        500
-      </Typography>
-      <Typography variant="body2">
-        何らかの理由でサーバーが応答していません。
-        <br />
-        時間をおいて再度アクセスするか、 サイトの管理者にお問い合わせください。
-      </Typography>
-    </Box>
+    <ErrorMessage
+      errorCode="500"
+      errorMessage={
+        <>
+          何らかの理由でサーバーが応答していません。
+          <br />
+          時間をおいて再度アクセスするか、
+          サイトの管理者にお問い合わせください。
+        </>
+      }
+    />
   )
 }
 

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { Typography, Box } from '@mui/material'
+
+const Error = () => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        textAlign: 'center',
+        height: 'calc(100vh - 64px)',
+        maxWidth: '70%',
+        margin: '0 auto',
+      }}
+    >
+      <Typography variant="h4" sx={{ color: '#1E90FF', mb: 1 }}>
+        500
+      </Typography>
+      <Typography variant="body2">
+        何らかの理由でサーバーが応答していません。
+        <br />
+        時間をおいて再度アクセスするか、 サイトの管理者にお問い合わせください。
+      </Typography>
+    </Box>
+  )
+}
+
+export default Error

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,27 +1,17 @@
-import { Box, Typography } from '@mui/material'
+import ErrorMessage from './components/ErrorMessage'
 
 const NotFound = () => {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        textAlign: 'center',
-        height: 'calc(100vh - 64px)',
-        maxWidth: '70%',
-        margin: '0 auto',
-      }}
-    >
-      <Typography variant="h4" sx={{ color: '#1E90FF', mb: 1 }}>
-        404
-      </Typography>
-      <Typography variant="body2">
-        お探しのページは存在しません。
-        <br />
-        一時的にアクセスできない状況にあるか、移動もしくは削除された可能性があります。
-      </Typography>
-    </Box>
+    <ErrorMessage
+      errorCode="404"
+      errorMessage={
+        <>
+          お探しのページは存在しません。
+          <br />
+          一時的にアクセスできない状況にあるか、移動もしくは削除された可能性があります。
+        </>
+      }
+    />
   )
 }
 

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,28 @@
+import { Box, Typography } from '@mui/material'
+
+const NotFound = () => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        textAlign: 'center',
+        height: 'calc(100vh - 64px)',
+        maxWidth: '70%',
+        margin: '0 auto',
+      }}
+    >
+      <Typography variant="h4" sx={{ color: '#1E90FF', mb: 1 }}>
+        404
+      </Typography>
+      <Typography variant="body2">
+        お探しのページは存在しません。
+        <br />
+        一時的にアクセスできない状況にあるか、移動もしくは削除された可能性があります。
+      </Typography>
+    </Box>
+  )
+}
+
+export default NotFound


### PR DESCRIPTION
# 概要
404、500画面の作成
# 再現手順
1. Topページ(`http://localhost:3001/`)に遷移
2. 存在しないページ(`http://localhost:3001/test`)に遷移
3. 404ページが表示される
# 期待する動作
Topページ(`http://localhost:3001/`)に遷移し、存在しないページ(`http://localhost:3001/test`)に遷移すると、404ページが表示されること