### PR TITLE
プライバシーポリシー、利用規約画面の作成

### DIFF
--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -1,0 +1,97 @@
+import { Box, Container, Typography } from '@mui/material'
+
+const fontStyle = { fontWeight: 'bold', mt: 2 }
+const borderStyle = { borderBottom: '1px solid #A0A0A0', mt: 0.5, mb: 1 }
+
+const Privacy = () => {
+  return (
+    <Container sx={{ mt: 3, mb: 11 }}>
+      <Typography
+        variant="body2"
+        sx={{ fontWeight: 'bold', mb: 2, textAlign: 'center' }}
+      >
+        プライバシーポリシー
+      </Typography>
+
+      <Typography variant="body2">
+        本ウェブサイト上で提供するサービス「HobbyLink」（以下,「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第1条（個人情報）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        「個人情報」とは，個人情報保護法にいう「個人情報」を指すものとし、特定の個人を識別できる情報（個人識別情報）を指します。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第2条（個人情報の収集方法）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        本サービスは、ユーザーが利用登録をする際に、Googleアカウント情報を取得します。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第3条（個人情報を収集・利用する目的）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2" sx={{ mb: 1 }}>
+        本サービスが個人情報を収集・利用する目的は，以下のとおりです。
+      </Typography>
+      <Typography variant="body2">1. 当社サービスの提供・運営のため</Typography>
+      <Typography variant="body2">
+        2. ユーザーからのお問い合わせに回答するため（本人確認を行うことを含む）
+      </Typography>
+      <Typography variant="body2">
+        3. メンテナンス，重要なお知らせなど必要に応じたご連絡のため
+      </Typography>
+      <Typography variant="body2">
+        4.
+        利用規約に違反したユーザーや，不正・不当な目的でサービスを利用しようとするユーザーの特定をし，ご利用をお断りするため
+      </Typography>
+      <Typography variant="body2">
+        5.
+        ユーザーにご自身の登録情報の閲覧や変更，削除，ご利用状況の閲覧を行っていただくため
+      </Typography>
+      <Typography variant="body2">6. 上記の利用目的に付随する目的</Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第4条（利用目的の変更）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        1.
+        本サービスは，利用目的が変更前と関連性を有すると合理的に認められる場合に限り，個人情報の利用目的を変更するものとします。
+      </Typography>
+      <Typography variant="body2">
+        2.
+        利用目的の変更を行った場合には，変更後の目的について，当社所定の方法により，ユーザーに通知し，または本ウェブサイト上に公表するものとします。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第5条（個人情報の第三者提供）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        本サービスは，ユーザーの同意を得ることなく，第三者に個人情報を提供することはありません。ただし，個人情報保護法その他の法令で認められる場合を除きます。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第6条（プライバシーポリシーの変更）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        1.
+        本ポリシーの内容は，法令その他本ポリシーに別段の定めのある事項を除いて，ユーザーに通知することなく，変更することができるものとします。
+      </Typography>
+      <Typography variant="body2">
+        2.
+        本サービスが別途定める場合を除いて，変更後のプライバシーポリシーは，本ウェブサイトに掲載したときから効力を生じるものとします。
+      </Typography>
+    </Container>
+  )
+}
+
+export default Privacy

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -1,0 +1,291 @@
+import { Box, Container, Typography } from '@mui/material'
+
+const fontStyle = { fontWeight: 'bold', mt: 2 }
+const borderStyle = { borderBottom: '1px solid #A0A0A0', mt: 0.5, mb: 1 }
+
+const Terms = () => {
+  return (
+    <Container sx={{ mt: 3, mb: 11 }}>
+      <Typography
+        variant="body2"
+        sx={{ fontWeight: 'bold', mb: 2, textAlign: 'center' }}
+      >
+        利用規約
+      </Typography>
+
+      <Typography variant="body2">
+        この利用規約（以下,「本規約」といいます。）は,「HobbyLink」以下,「当社」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第1条（適用）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        1.
+        本規約は，ユーザーと本サービスの利用に関わる一切の関係に適用されるものとします。
+      </Typography>
+      <Typography variant="body2">
+        2.
+        本サービスに関し，本規約のほか，ご利用にあたってのルール等，各種の定め（以下，「個別規定」といいます。）をすることがあります。これら個別規定はその名称のいかんに関わらず，本規約の一部を構成するものとします。
+      </Typography>
+      <Typography variant="body2">
+        3.
+        本規約の規定が前条の個別規定の規定と矛盾する場合には，個別規定において特段の定めなき限り，個別規定の規定が優先されるものとします。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第2条（利用登録）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        1.
+        本サービスにおいては，登録希望者が本規約に同意の上，当社の定める方法によって利用登録を申請し，当社がこの承認を登録希望者に通知することによって，利用登録が完了するものとします。
+      </Typography>
+      <Typography variant="body2">
+        2.
+        本サービスは，利用登録の申請者に以下の事由があると判断した場合，利用登録の申請を承認しないことがあり，その理由については一切の開示義務を負わないものとします。
+      </Typography>
+      <Typography variant="body2">
+        ・ 利用登録の申請に際して虚偽の事項を届け出た場合
+      </Typography>
+      <Typography variant="body2">
+        ・ 本規約に違反したことがある者からの申請である場合
+      </Typography>
+      <Typography variant="body2">
+        ・ その他，当社が利用登録を相当でないと判断した場合
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第3条（ユーザーIDおよびパスワードの管理）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        1.
+        ユーザーは,自己の責任において,本サービスのユーザーIDおよびパスワードを適切に管理するものとします。
+      </Typography>
+      <Typography variant="body2">
+        2.
+        ユーザーは,いかなる場合にも,ユーザーIDおよびパスワードを第三者に譲渡または貸与し,もしくは第三者と共用することはできません。本サービスは,ユーザーIDとパスワードの組み合わせが登録情報と一致してログインされた場合には,そのユーザーIDを登録しているユーザー自身による利用とみなします。
+      </Typography>
+      <Typography variant="body2">
+        3.
+        ユーザーID及びパスワードが第三者によって使用されたことによって生じた損害は,本サービスは一切の責任を負わないものとします。
+      </Typography>
+      <Typography variant="body2" sx={fontStyle}>
+        第4条（利用料金および支払方法）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        ユーザーは、本サービスを無料で利用することができます。本サービスは、利用料金を請求することはありません
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第5条（禁止事項）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2" sx={{ mb: 1 }}>
+        ユーザーは，本サービスの利用にあたり，以下の行為をしてはなりません。
+      </Typography>
+      <Typography variant="body2">
+        1. 法令または公序良俗に違反する行為
+      </Typography>
+      <Typography variant="body2">2. 犯罪行為に関連する行為</Typography>
+      <Typography variant="body2">
+        3.
+        本サービスの他のユーザー，または第三者のサーバーまたはネットワークの機能を破壊したり，妨害したりする行為
+      </Typography>
+      <Typography variant="body2">
+        4. 本サービスの運営を妨害するおそれのある行為
+      </Typography>
+      <Typography variant="body2">
+        5. 他のユーザーに関する個人情報等を収集または蓄積する行為
+      </Typography>
+      <Typography variant="body2">
+        6. 不正アクセスをし，またはこれを試みる行為
+      </Typography>
+      <Typography variant="body2">7. 他のユーザーに成りすます行為</Typography>
+      <Typography variant="body2">
+        8.
+        本サービスに関連して，反社会的勢力に対して直接または間接に利益を供与する行為
+      </Typography>
+      <Typography variant="body2">
+        9.
+        本サービスの他のユーザーまたは第三者の知的財産権，肖像権，プライバシー，名誉その他の権利または利益を侵害する行為
+      </Typography>
+      <Typography variant="body2">
+        10.
+        以下の表現を含み，または含むと当社が判断する内容を本サービス上に投稿し，または送信する行為
+      </Typography>
+      <Typography variant="body2">・ 過度に暴力的な表現</Typography>
+      <Typography variant="body2">・ 露骨な性的表現</Typography>
+      <Typography variant="body2">
+        ・ 人種，国籍，信条，性別，社会的身分，門地等による差 別につながる表現
+      </Typography>
+      <Typography variant="body2">
+        ・ 自殺，自傷行為，薬物乱用を誘引または助長する表現
+      </Typography>
+      <Typography variant="body2">
+        ・ その他反社会的な内容を含み他人に不快感を与える表現
+      </Typography>
+      <Typography variant="body2">
+        11. 以下を目的とし，または目的とすると当社が判断する行為
+      </Typography>
+      <Typography variant="body2">
+        ・
+        営業，宣伝，広告，勧誘，その他営利を目的とする行為（当社の認めたものを除きます。）
+      </Typography>
+      <Typography variant="body2">
+        ・ 性行為やわいせつな行為を目的とする行為
+      </Typography>
+      <Typography variant="body2">
+        ・ 面識のない異性との出会いや交際を目的とする行為
+      </Typography>
+      <Typography variant="body2">
+        ・ 他のユーザーに対する嫌がらせや誹謗中傷を目的とする行為
+      </Typography>
+      <Typography variant="body2">
+        ・
+        本サービスの他のユーザー，または第三者に不利益，損害または不快感を与えることを目的とする行為
+      </Typography>
+      <Typography variant="body2">
+        ・
+        その他本サービスが予定している利用目的と異なる目的で本サービスを利用する行為
+      </Typography>
+      <Typography variant="body2">
+        12. 宗教活動または宗教団体への勧誘行為
+      </Typography>
+      <Typography variant="body2">
+        13. その他，当社が不適切と判断する行為
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第6条（本サービスの提供の停止等）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        1.
+        本サービスは，以下のいずれかの事由があると判断した場合，ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
+      </Typography>
+      <Typography variant="body2">
+        ・ 本サービスにかかるコンピュータシステムの保守点検または更新を行う場合
+      </Typography>
+      <Typography variant="body2">
+        ・
+        地震，落雷，火災，停電または天災などの不可抗力により，本サービスの提供が困難となった場合
+        ・ コンピュータまたは通信回線等が事故により停止した場合
+      </Typography>
+      <Typography variant="body2">
+        ・ その他，本サービスの提供が困難と判断した場合
+      </Typography>
+      <Typography variant="body2">
+        ・
+        本サービスの提供の停止または中断により，ユーザーまたは第三者が被ったいかなる不利益または損害についても，一切の責任を負わないものとします。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第7条（利用制限および登録抹消）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        1.
+        本サービスは，ユーザーが以下のいずれかに該当する場合には，事前の通知なく，投稿データを削除し，ユーザーに対して本サービスの全部もしくは一部の利用を制限しまたはユーザーとしての登録を抹消することができるものとします。
+      </Typography>
+      <Typography variant="body2">
+        ・ 本規約のいずれかの条項に違反した場合
+      </Typography>
+      <Typography variant="body2">
+        ・ 登録事項に虚偽の事実があることが判明した場合
+      </Typography>
+      <Typography variant="body2">
+        ・ 本サービスからの連絡に対し，一定期間返答がない場合
+      </Typography>
+      <Typography variant="body2">
+        ・ 本サービスについて，最終の利用から一定期間利用がない場合
+      </Typography>
+      <Typography variant="body2">
+        ・ その他，当社が本サービスの利用を適当でないと判断した場合
+      </Typography>
+      <Typography variant="body2">
+        2.
+        本サービスは，本条に基づき行った行為によりユーザーに生じた損害について，一切の責任を負いません。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第8条（保証の否認および免責事項）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        1.
+        本サービスは事実上または法律上の瑕疵（安全性，信頼性，正確性，完全性，有効性，特定の目的への適合性，セキュリティなどに関する欠陥，エラーやバグ，権利侵害などを含みます。）がないことを明示的にも黙示的にも保証しておりません。
+      </Typography>
+      <Typography variant="body2">
+        2.
+        本サービスは、ユーザーに生じたあらゆる損害について、一切の責任を負いません。
+      </Typography>
+      <Typography variant="body2">
+        3.
+        本サービスは、ユーザーと他のユーザーまたは第三者との間において生じた取引，連絡または紛争等について一切責任を負いません。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第9条（サービス内容の変更等）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        本サービスは，ユーザーへの事前の告知をもって、本サービスの内容を変更、追加または廃止することがあり、ユーザーはこれを承諾するものとします。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第10条（利用規約の変更）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        1.
+        本サービスは、ユーザーの個別の同意を要せず、本規約を変更することができるものとします。
+      </Typography>
+      <Typography variant="body2">
+        2.
+        本サービスは、本規約の変更後にユーザーが本サービスを利用した場合、変更後の規約に同意したものとみなします。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第11条（個人情報の取扱い）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        本サービスの利用によって取得する個人情報については，当社「プライバシーポリシー」に従い適切に取り扱うものとします。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第12条（通知または連絡）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        ユーザーと当社との間の通知または連絡は，当社の定める方法によって行うものとします。当社は,ユーザーから,当社が別途定める方式に従った変更届け出がない限り,現在登録されている連絡先が有効なものとみなして当該連絡先へ通知または連絡を行い,これらは,発信時にユーザーへ到達したものとみなします。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第13条（権利義務の譲渡の禁止）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        ユーザーは，当社の書面による事前の承諾なく，利用契約上の地位または本規約に基づく権利もしくは義務を第三者に譲渡し，または担保に供することはできません。
+      </Typography>
+
+      <Typography variant="body2" sx={fontStyle}>
+        第14条（準拠法・裁判管轄）
+      </Typography>
+      <Box sx={borderStyle} />
+      <Typography variant="body2">
+        1. 本規約の解釈にあたっては，日本法を準拠法とします。
+      </Typography>
+      <Typography variant="body2">
+        2.
+        本サービスに関して紛争が生じた場合には，当社の本店所在地を管轄する裁判所を専属的合意管轄とします。
+      </Typography>
+    </Container>
+  )
+}
+
+export default Terms


### PR DESCRIPTION
# 概要
プライバシーポリシー、利用規約画面の作成
# 再現手順
1. 利用規約ページ(`http://localhost:3001/terms`)に遷移
2. 利用規約ページが表示される
3. プライバシーポリシーページ(`http://localhost:3001/privacy`)に遷移
4. プライバシーポリシーページが表示される
# 期待する動作
利用規約ページ(`http://localhost:3001/terms`)に遷移すると、利用規約ページが表示されること
プライバシーポリシーページ(`http://localhost:3001/privacy`)に遷移すると、プライバシーポリシーページが表示されること