### PR TITLE
商品追加画面の作成

### DIFF
--- a/backend/app/controllers/api/v1/products_controller.rb
+++ b/backend/app/controllers/api/v1/products_controller.rb
@@ -5,7 +5,21 @@ class Api::V1::ProductsController < ApplicationController
   def search
     return unless params[:keyword]
 
-    products = RakutenWebService::Ichiba::Item.search(keyword: params[:keyword]).first(20)
+    response = RakutenWebService::Ichiba::Item.search(keyword: params[:keyword]).first(20)
+
+    products = []
+
+    response.each do |product|
+      products << {
+        item_code: product['item_code'],
+        item_name: product['item_name'],
+        item_caption: product['item_caption'],
+        item_price: product['item_price'],
+        mediumImageUrls: product['mediumImageUrls'][0].gsub('?_ex=128x128', ''),
+        item_url: product['affiliate_url']
+      }
+    end
+
     render json: products, status: :ok
   end
 end

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -22,6 +22,10 @@ const nextConfig = {
         protocol: 'http',
         hostname: 'localhost',
       },
+      {
+        protocol: 'https',
+        hostname: 'thumbnail.image.rakuten.co.jp',
+      },
     ],
   },
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/material": "^6.1.2",
         "@mui/material-nextjs": "^6.1.2",
         "axios": "^1.7.7",
+        "camelcase-keys": "^9.1.3",
         "i": "^0.3.7",
         "next": "14.2.13",
         "next-auth": "^4.24.8",
@@ -1893,6 +1894,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-9.1.3.tgz",
+      "integrity": "sha512-Rircqi9ch8AnZscQcsA1C47NFdaO3wukpmIRzYcDOrmvgt78hM/sj5pZhZNec2NM12uk5vTwRHZ4anGcrC4ZTg==",
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^8.0.0",
+        "map-obj": "5.0.0",
+        "quick-lru": "^6.1.1",
+        "type-fest": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/type-fest": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4338,6 +4381,18 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/map-obj": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-5.0.0.tgz",
+      "integrity": "sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7954,6 +8009,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@mui/material": "^6.1.2",
     "@mui/material-nextjs": "^6.1.2",
     "axios": "^1.7.7",
+    "camelcase-keys": "^9.1.3",
     "i": "^0.3.7",
     "next": "14.2.13",
     "next-auth": "^4.24.8",

--- a/frontend/src/app/components/Error.tsx
+++ b/frontend/src/app/components/Error.tsx
@@ -1,5 +1,12 @@
+import ErrorMessage from './ErrorMessage'
+
 const Error = () => {
-  return <div>Error</div>
+  return (
+    <ErrorMessage
+      errorCode="通信エラー"
+      errorMessage="データの取得に失敗しました。後ほど再試行してください。"
+    />
+  )
 }
 
 export default Error

--- a/frontend/src/app/components/Footer.tsx
+++ b/frontend/src/app/components/Footer.tsx
@@ -5,21 +5,22 @@ import HomeIcon from '@mui/icons-material/Home'
 import NotificationsIcon from '@mui/icons-material/Notifications'
 import PersonIcon from '@mui/icons-material/Person'
 import SearchIcon from '@mui/icons-material/Search'
-import {
-  BottomNavigation,
-  BottomNavigationAction,
-  Box,
-  Typography,
-} from '@mui/material'
+import BottomNavigation from '@mui/material/BottomNavigation'
+import BottomNavigationAction from '@mui/material/BottomNavigationAction'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
 import { useRouter, usePathname } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useEffect, useState, useContext } from 'react'
+import LoginModal from './LoginModal'
+import { ProductContext } from '@/contexts/ProductContext'
 
 const getInitValue = (pathname: string) => {
   if (pathname === '/') return 0
   if (pathname.startsWith('/search')) return 1
   if (pathname.startsWith('/posts')) return 2
   if (pathname.startsWith('/notifications')) return 3
-  if (pathname.startsWith('/mypage')) return 4
+  if (pathname.startsWith('/my-page')) return 4
   return 0
 }
 
@@ -27,8 +28,21 @@ const Footer = () => {
   const router = useRouter()
   const pathname = usePathname()
   const [value, setValue] = useState(getInitValue(pathname))
+  const { resetFormData } = useContext(ProductContext)
+  const [open, setOpen] = useState<boolean>(false)
+  const handleOpen = () => setOpen(true)
+  const handleClose = () => setOpen(false)
+  const { data: session } = useSession()
 
   useEffect(() => setValue(getInitValue(pathname)), [pathname])
+
+  const checkUserLogin = (path: string) => {
+    if (session?.user) {
+      router.push(path)
+    } else {
+      handleOpen()
+    }
+  }
 
   return (
     <Box
@@ -44,6 +58,8 @@ const Footer = () => {
         showLabels
         value={value}
         onChange={(event, newValue) => {
+          if (newValue !== 2) resetFormData()
+
           switch (newValue) {
             case 0:
               router.push('/')
@@ -52,13 +68,13 @@ const Footer = () => {
               router.push('/search')
               break
             case 2:
-              router.push('/posts')
+              checkUserLogin('/posts')
               break
             case 3:
-              router.push('/notifications')
+              checkUserLogin('/notifications')
               break
             case 4:
-              router.push('/my-page')
+              checkUserLogin('/my-page')
               break
           }
         }}
@@ -89,6 +105,7 @@ const Footer = () => {
           disableRipple
         />
       </BottomNavigation>
+      <LoginModal open={open} handleClose={handleClose} />
     </Box>
   )
 }

--- a/frontend/src/app/components/Header.tsx
+++ b/frontend/src/app/components/Header.tsx
@@ -19,6 +19,7 @@ import {
 } from '@mui/material'
 import Image from 'next/image'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { useSession, signOut } from 'next-auth/react'
 import { useState } from 'react'
 import LoginModal from './LoginModal'
@@ -38,6 +39,11 @@ const Header = () => {
     setAnchorElUser(null)
   }
   const { data: session } = useSession()
+
+  const hiddenPathnames = ['/posts/search']
+  const pathname = usePathname()
+
+  if (hiddenPathnames.includes(pathname)) return <></>
 
   return (
     <Box>

--- a/frontend/src/app/components/Loading.tsx
+++ b/frontend/src/app/components/Loading.tsx
@@ -7,7 +7,8 @@ const Loading = () => {
       sx={{
         display: 'flex',
         justifyContent: 'center',
-        height: '100vh',
+        alignItems: 'center',
+        height: 'calc(100vh - 64px)',
       }}
     >
       <Image src="/loading.svg" alt="Loading..." width={90} height={90}></Image>

--- a/frontend/src/app/components/NavigationHeader.tsx
+++ b/frontend/src/app/components/NavigationHeader.tsx
@@ -1,0 +1,39 @@
+import ArrowBackSharpIcon from '@mui/icons-material/ArrowBackSharp'
+import { Box, Typography, IconButton, AppBar, Toolbar } from '@mui/material'
+import { useRouter } from 'next/navigation'
+
+type NavigationHeaderProps = {
+  title: string
+}
+const NavigationHeader = ({ title }: NavigationHeaderProps) => {
+  const router = useRouter()
+
+  return (
+    <AppBar
+      position="static"
+      elevation={0}
+      sx={{
+        backgroundColor: 'white',
+        borderBottom: '1px solid #E0E0E0',
+      }}
+    >
+      <Toolbar sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Box sx={{ position: 'absolute', left: 15 }}>
+          <IconButton size="small" onClick={router.back}>
+            <ArrowBackSharpIcon sx={{ color: '#666666' }} />
+          </IconButton>
+        </Box>
+        <Box>
+          <Typography
+            variant="body2"
+            sx={{ fontWeight: 'bold', color: 'black' }}
+          >
+            {title}
+          </Typography>
+        </Box>
+      </Toolbar>
+    </AppBar>
+  )
+}
+
+export default NavigationHeader

--- a/frontend/src/app/components/ProductCard.tsx
+++ b/frontend/src/app/components/ProductCard.tsx
@@ -1,0 +1,77 @@
+import { Card, CardContent, Typography, Box } from '@mui/material'
+import Image from 'next/image'
+import { useContext } from 'react'
+import { ProductContext } from '@/contexts/ProductContext'
+
+type ProductCardProps = {
+  id: string
+  name: string
+  price: number
+  image: string
+  selected: boolean
+  deletable: boolean
+}
+
+const ProductCard = (props: ProductCardProps) => {
+  const { deleteProduct } = useContext(ProductContext)
+
+  return (
+    <>
+      <Card
+        sx={{
+          border: props.selected
+            ? '1.6px #1E90FF solid'
+            : '1.6px #D9D9D9 solid',
+          position: 'relative',
+        }}
+      >
+        <Box sx={{ position: 'relative', width: '100%', height: 125 }}>
+          <Image
+            src={props.image}
+            alt={props.name}
+            fill
+            style={{ width: '100%', height: '100%' }}
+            sizes="(max-width: 600px) 50vw, (max-width: 1200px) 33vw, 25vw"
+          />
+        </Box>
+        <CardContent sx={{ height: 75, pt: 1 }}>
+          <Typography
+            sx={{
+              color: 'black',
+              fontSize: 10.5,
+              fontWeight: 'medium',
+              mb: 1,
+              display: '-webkit-box',
+              overflow: 'hidden',
+              WebkitBoxOrient: 'vertical',
+              WebkitLineClamp: 2,
+            }}
+          >
+            {props.name}
+          </Typography>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            <Typography
+              sx={{ color: 'red', fontSize: 12.5, fontWeight: 'bold' }}
+            >
+              {props.price}円
+            </Typography>
+            {props.deletable && (
+              <Typography
+                sx={{
+                  color: '#1E90FF',
+                  fontSize: 12,
+                  fontWeight: 'bold',
+                }}
+                onClick={() => deleteProduct(props.id)}
+              >
+                削除
+              </Typography>
+            )}
+          </Box>
+        </CardContent>
+      </Card>
+    </>
+  )
+}
+
+export default ProductCard

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter'
 import type { Metadata } from 'next'
 import Footer from './components/Footer'
 import Header from './components/Header'
+import { NotificationProvider } from '@/contexts/NotificationContext'
+import { ProductProvider } from '@/contexts/ProductContext'
 import NextAuthProvider from '@/providers/NextAuth'
 import theme from '@/styles/theme'
 import '@/styles/destyle.css'
@@ -25,9 +27,13 @@ export default function RootLayout({
           <AppRouterCacheProvider>
             <ThemeProvider theme={theme}>
               <CssBaseline />
-              <Header />
-              {children}
-              <Footer />
+              <ProductProvider>
+                <NotificationProvider>
+                  <Header />
+                  {children}
+                  <Footer />
+                </NotificationProvider>
+              </ProductProvider>
             </ThemeProvider>
           </AppRouterCacheProvider>
         </NextAuthProvider>

--- a/frontend/src/app/posts/search/page.tsx
+++ b/frontend/src/app/posts/search/page.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import SearchIcon from '@mui/icons-material/Search'
+import {
+  Box,
+  Container,
+  TextField,
+  InputAdornment,
+  Button,
+  Typography,
+} from '@mui/material'
+import Grid from '@mui/material/Grid2'
+import camelcaseKeys from 'camelcase-keys'
+import { useRouter } from 'next/navigation'
+import { useState, useContext } from 'react'
+import useSWR from 'swr'
+import Error from '@/app/components/Error'
+import Loading from '@/app/components/Loading'
+import NavigationHeader from '@/app/components/NavigationHeader'
+import ProductCard from '@/app/components/ProductCard'
+import ValidationMessage from '@/app/components/ValidationMessage'
+import { ProductContext, RakutenProduct } from '@/contexts/ProductContext'
+import { fetcher } from '@/utils/fetcher'
+import { searchProductsUrl } from '@/utils/urls'
+
+const Search = () => {
+  const [keyword, setKeyword] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
+  const { formData, addProducts } = useContext(ProductContext)
+  const [selectedProducts, setSelectedProducts] = useState<RakutenProduct[]>(
+    formData.products,
+  )
+  const router = useRouter()
+
+  const validateKeyword = (keyword: string) => {
+    if (keyword.length < 2) {
+      setErrorMessage('キーワードは2文字以上で入力してください。')
+      return false
+    } else {
+      setErrorMessage('')
+      return true
+    }
+  }
+
+  const addProduct = (product: RakutenProduct) => {
+    setSelectedProducts((prev) =>
+      prev.some((currentProd) => currentProd.itemCode === product.itemCode)
+        ? prev.filter(
+            (currentProd) => currentProd.itemCode !== product.itemCode,
+          )
+        : [...prev, product],
+    )
+  }
+
+  const handleAddProducts = () => {
+    addProducts(selectedProducts)
+    router.push('/posts')
+  }
+
+  // 楽天商品データを取得
+  const { data, error, isLoading } = useSWR(
+    keyword
+      ? searchProductsUrl +
+          new URLSearchParams({
+            keyword: keyword,
+          })
+      : null,
+    fetcher,
+  )
+
+  const products = data ? camelcaseKeys(data) : []
+
+  return (
+    <>
+      <NavigationHeader title="商品を検索" />
+
+      {error ? (
+        <Error />
+      ) : (
+        <Container
+          maxWidth="sm"
+          sx={{
+            mt: 4,
+            mb: 11,
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: '100vh',
+          }}
+        >
+          <Box sx={{ flex: 1 }}>
+            <Box sx={{ display: 'flex' }}>
+              <TextField
+                size="small"
+                placeholder="キーワードを入力してください"
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <SearchIcon />
+                      </InputAdornment>
+                    ),
+                    style: { height: 35 },
+                  },
+                }}
+                sx={{ width: '100%', backgroundColor: 'white' }}
+                onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                  const keyword = (e.target as HTMLInputElement).value
+
+                  if (e.key === 'Enter' && validateKeyword(keyword)) {
+                    setKeyword(keyword)
+                  }
+                }}
+              />
+            </Box>
+            {errorMessage && <ValidationMessage message={errorMessage} />}
+
+            {isLoading ? (
+              <Loading />
+            ) : keyword && products.length === 0 ? (
+              <Typography variant="body2" sx={{ mt: 2, textAlign: 'center' }}>
+                検索結果が見つかりませんでした。
+              </Typography>
+            ) : (
+              <Grid container spacing={5} sx={{ mt: 4 }}>
+                {products.map((product: RakutenProduct) => (
+                  <Grid
+                    size={{ xs: 6, sm: 4 }}
+                    key={product.itemCode}
+                    onClick={() => addProduct(product)}
+                    sx={{ cursor: 'pointer' }}
+                  >
+                    <ProductCard
+                      id={product.itemCode}
+                      name={product.itemName}
+                      price={product.itemPrice}
+                      image={product.mediumImageUrls}
+                      selected={selectedProducts.some(
+                        (selected: RakutenProduct) =>
+                          selected.itemCode === product.itemCode,
+                      )}
+                      deletable={false}
+                    />
+                  </Grid>
+                ))}
+              </Grid>
+            )}
+          </Box>
+
+          <Box sx={{ mt: 4 }}>
+            <Button
+              variant="contained"
+              sx={{
+                width: '100%',
+                backgroundColor: 'black',
+                color: 'white',
+              }}
+              disabled={selectedProducts.length === 0}
+              onClick={handleAddProducts}
+            >
+              {selectedProducts.length} 個の商品を追加
+            </Button>
+          </Box>
+        </Container>
+      )}
+    </>
+  )
+}
+
+export default Search

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import CheckIcon from '@mui/icons-material/Check'
+import { Snackbar, Alert, Box } from '@mui/material'
+import { usePathname } from 'next/navigation'
+import { createContext, useState, useEffect } from 'react'
+
+type NotificationProviderProps = {
+  children: React.ReactNode
+}
+
+type Notification = {
+  message: null | string
+  severity: null | 'info' | 'error'
+  pathname: null | string
+}
+
+type NotificationContextType = {
+  setNotification: (props: Notification) => void
+}
+
+const NotificationContext = createContext<NotificationContextType>({
+  setNotification: () => {},
+})
+
+const NotificationProvider = ({ children }: NotificationProviderProps) => {
+  const [notification, setNotification] = useState<Notification>({
+    message: null,
+    severity: null,
+    pathname: null,
+  })
+  const [open, setOpen] = useState(true)
+  const pathName = usePathname()
+
+  const handleClose = (
+    event: React.SyntheticEvent | Event,
+    reason?: string,
+  ) => {
+    if (reason === 'clickaway') {
+      return
+    }
+    setOpen(false)
+    setNotification({ message: null, severity: null, pathname: null })
+  }
+
+  useEffect(() => {
+    if (notification.pathname === pathName) {
+      setOpen(true)
+    }
+  }, [notification, pathName])
+
+  return (
+    <NotificationContext.Provider value={{ setNotification }}>
+      {notification.severity && (
+        <Box
+          sx={{
+            position: 'relative',
+          }}
+        >
+          <Snackbar
+            anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+            open={open}
+            autoHideDuration={2000}
+            onClose={handleClose}
+          >
+            <Alert
+              icon={<CheckIcon fontSize="inherit" />}
+              severity={notification.severity}
+              sx={{
+                width: 245,
+                height: 48,
+              }}
+            >
+              {notification.message}
+            </Alert>
+          </Snackbar>
+        </Box>
+      )}
+      {children}
+    </NotificationContext.Provider>
+  )
+}
+
+export { NotificationContext, NotificationProvider }

--- a/frontend/src/contexts/ProductContext.tsx
+++ b/frontend/src/contexts/ProductContext.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { createContext, useState } from 'react'
+
+type ProductProviderProps = {
+  children: React.ReactNode
+}
+
+type RakutenProduct = {
+  itemCode: string
+  itemName: string
+  itemCaption: string
+  itemPrice: number
+  mediumImageUrls: string
+  itemUrl: string
+}
+
+type Form = {
+  image: File | null
+  content: string
+  category: string
+  products: RakutenProduct[]
+}
+
+type ProductContextType = {
+  formData: Form
+  setField: (key: string, value: File | string) => void
+  addProducts: (product: RakutenProduct[]) => void
+  deleteProduct: (itemCode: string) => void
+  resetFormData: () => void
+}
+
+const ProductContext = createContext<ProductContextType>({
+  formData: {
+    image: null,
+    content: '',
+    category: '',
+    products: [],
+  },
+  setField: () => {},
+  addProducts: () => {},
+  deleteProduct: () => {},
+  resetFormData: () => {},
+})
+
+const ProductProvider = ({ children }: ProductProviderProps) => {
+  const [formData, setFormData] = useState<Form>({
+    image: null,
+    content: '',
+    category: '',
+    products: [],
+  })
+
+  const setField = (key: string, value: File | string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [key]: value,
+    }))
+  }
+
+  const addProducts = (products: RakutenProduct[]) => {
+    setFormData((prev) => ({
+      ...prev,
+      products: [...products],
+    }))
+  }
+
+  const deleteProduct = (itemCode: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      products: prev.products.filter(
+        (currentProduct) => currentProduct.itemCode !== itemCode,
+      ),
+    }))
+  }
+
+  const resetFormData = () => {
+    setFormData({
+      image: null,
+      content: '',
+      category: '',
+      products: [],
+    })
+  }
+  return (
+    <ProductContext.Provider
+      value={{ formData, setField, addProducts, deleteProduct, resetFormData }}
+    >
+      {children}
+    </ProductContext.Provider>
+  )
+}
+
+export type { RakutenProduct, Form }
+export { ProductContext, ProductProvider }

--- a/frontend/src/utils/urls.ts
+++ b/frontend/src/utils/urls.ts
@@ -1,9 +1,18 @@
 const HOST_API_URL = process.env.NEXT_PUBLIC_API_URL
 const DOCKER_API_URL = process.env.NEXT_PUBLIC_DOCKER_API_URL
 
+// APIチェック用URL（GET）
 export const apiCheckUrl = `${HOST_API_URL}/api_check`
 
+// サインイン用URL（POST）
 export const signInUrl = (provider: string) =>
   `${DOCKER_API_URL}/auth/${provider}/callback`
 
+// カテゴリー一覧取得用のURL（GET）
 export const categoriesUrl = `${HOST_API_URL}/categories`
+
+// 商品検索用URL（GET）
+export const searchProductsUrl = `${HOST_API_URL}/products/search?`
+
+// 投稿用URL（POST）
+export const createPostUrl = `${HOST_API_URL}/posts`


### PR DESCRIPTION
# 概要
商品追加画面の作成
# 再現手順
1. 投稿ページ(`http://localhost:3001/posts`)に遷移 
2. 商品追加ボタンをクリック
3. 商品検索ページ(`http://localhost:3001/posts/search`)に遷移
4. キーワードを2文字以上入力し、検索
5. 商品一覧が表示される
6. 商品を選択
7. 選択された商品の枠が青く表示
8. 追加ボタンをクリック
9. 投稿ページ(`http://localhost:3001/posts`に遷移 
10. 選択した商品が表示される
# 期待する動作
投稿ページ(`http://localhost:3001/posts`に遷移し、商品追加ボタンをクリックすると、商品検索ページ(`http://localhost:3001/posts/search`)に遷移し、キーワードを2文字以上入力し、検索すると、商品一覧が表示される。
商品を選択すると、選択された商品の枠が青く表示し、追加ボタンをクリックすると、投稿ページ(`http://localhost:3001/posts`に遷移し、選択した商品が表示されること。