### PR TITLE
投稿詳細画面の作成

### DIFF
--- a/backend/app/controllers/api/v1/categories_controller.rb
+++ b/backend/app/controllers/api/v1/categories_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::CategoriesController < ApplicationController
   def index
     categories = Category.all
-    render json: categories, status: :ok
+    render json: categories, each_serializer: PostCategorySerializer, status: :ok
   end
 end

--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -3,6 +3,11 @@ require 'open-uri'
 class Api::V1::PostsController < ApplicationController
   before_action :authenticate, only: [:create]
 
+  def show
+    posts = Post.includes(:user, :category, :products).find(params[:id])
+    render json: posts, status: :ok
+  end
+
   def create
     ActiveRecord::Base.transaction do
       post = @current_user.posts.new(post_params)

--- a/backend/app/controllers/concerns/url_host.rb
+++ b/backend/app/controllers/concerns/url_host.rb
@@ -1,0 +1,7 @@
+module UrlHost
+  extend ActiveSupport::Concern
+
+  def self.host
+    Rails.env.production? ? 'hobbylink-66d327f4790b.herokuapp.com' : 'localhost:3000'
+  end
+end

--- a/backend/app/serializers/post_category_serializer.rb
+++ b/backend/app/serializers/post_category_serializer.rb
@@ -1,0 +1,3 @@
+class PostCategorySerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/backend/app/serializers/post_product_serializer.rb
+++ b/backend/app/serializers/post_product_serializer.rb
@@ -1,0 +1,9 @@
+class PostProductSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+
+  attributes :id, :name, :image, :price
+
+  def image
+    object.image.attached? ? rails_blob_url(object.image) : nil
+  end
+end

--- a/backend/app/serializers/post_product_serializer.rb
+++ b/backend/app/serializers/post_product_serializer.rb
@@ -6,4 +6,8 @@ class PostProductSerializer < ActiveModel::Serializer
   def image
     object.image.attached? ? rails_blob_url(object.image) : nil
   end
+
+  def price
+    object.price.to_i
+  end
 end

--- a/backend/app/serializers/post_serializer.rb
+++ b/backend/app/serializers/post_serializer.rb
@@ -1,0 +1,30 @@
+class PostSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+
+  attributes :id, :image, :content, :created_at
+
+  belongs_to :user,     serializer: PostUserSerializer
+  belongs_to :category, serializer: PostCategorySerializer
+  has_many   :products, serializer: PostProductSerializer
+
+  def image
+    object.image.attached? ? rails_blob_url(object.image) : nil
+  end
+
+  def created_at
+    diff_time = Time.current - object.created_at
+
+    case diff_time
+    when 0..60
+      "#{diff_time.to_i}秒前"
+    when 60..3600
+      "#{(diff_time / 60).to_i}分前"
+    when 3600..86_400
+      "#{(diff_time / 3600).to_i}時間前"
+    when 86_400..604_800
+      "#{(diff_time / 86_400).to_i}日前"
+    else
+      object.created_at.strftime('%Y年%m月%日')
+    end
+  end
+end

--- a/backend/app/serializers/post_user_serializer.rb
+++ b/backend/app/serializers/post_user_serializer.rb
@@ -1,0 +1,9 @@
+class PostUserSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+
+  attributes :id, :image, :name
+
+  def image
+    object.image.attached? ? rails_blob_url(object.image) : nil
+  end
+end

--- a/backend/app/serializers/post_user_serializer.rb
+++ b/backend/app/serializers/post_user_serializer.rb
@@ -4,6 +4,6 @@ class PostUserSerializer < ActiveModel::Serializer
   attributes :id, :image, :name
 
   def image
-    object.image.attached? ? rails_blob_url(object.image) : nil
+    object.image.attached? ? rails_blob_url(object.image, host: UrlHost.host) : nil
   end
 end

--- a/backend/app/serializers/user_serializer.rb
+++ b/backend/app/serializers/user_serializer.rb
@@ -22,7 +22,7 @@ class UserSerializer < ActiveModel::Serializer
   attributes :id, :name, :image, :bio, :token
 
   def image
-    object.image.attached? ? rails_blob_url(object.image) : nil
+    object.image.attached? ? rails_blob_url(object.image, host: UrlHost.host) : nil
   end
 
   def token

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -71,5 +71,5 @@ Rails.application.configure do
   # config.generators.apply_rubocop_autocorrect_after_generate!
   config.hosts << "backend:3000"
 
-  Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+  Rails.application.routes.default_url_options[:host] = 'backend:3000'
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,9 +1,12 @@
+# == Route Map
+#
+
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post "auth/:provider/callback", to: "users#create"
       get "api_check", to: "api_check#index"
-      resources :posts, only: [:create]
+      resources :posts, only: [:create, :show]
       resources :categories, only: [:index]
       resources :products, only: [:show] do
         collection do

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -23,6 +23,10 @@ const nextConfig = {
         hostname: 'localhost',
       },
       {
+        protocol: 'http',
+        hostname: 'backend',
+      },
+      {
         protocol: 'https',
         hostname: 'thumbnail.image.rakuten.co.jp',
       },

--- a/frontend/src/app/components/Header.tsx
+++ b/frontend/src/app/components/Header.tsx
@@ -42,8 +42,9 @@ const Header = () => {
 
   const hiddenPathnames = ['/posts/search']
   const pathname = usePathname()
+  const isPathMatch = /\/posts\/\d+$/.test(pathname)
 
-  if (hiddenPathnames.includes(pathname)) return <></>
+  if (isPathMatch || hiddenPathnames.includes(pathname)) return <></>
 
   return (
     <Box>

--- a/frontend/src/app/posts/[id]/page.tsx
+++ b/frontend/src/app/posts/[id]/page.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined'
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
+import MoreVertIcon from '@mui/icons-material/MoreVert'
+import {
+  Box,
+  Typography,
+  Container,
+  Avatar,
+  IconButton,
+  Tooltip,
+  Menu,
+  Paper,
+  MenuItem,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  Button,
+} from '@mui/material'
+import Grid from '@mui/material/Grid2'
+import camelcaseKeys from 'camelcase-keys'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { useState } from 'react'
+import useSWR from 'swr'
+import Error from '@/app/components/Error'
+import Loading from '@/app/components/Loading'
+import NavigationHeader from '@/app/components/NavigationHeader'
+import ProductCard from '@/app/components/ProductCard'
+import { fetcher } from '@/utils/fetcher'
+import { getPostByIdUrl } from '@/utils/urls'
+
+type Post = {
+  id: number
+  image: string
+  content: string
+  createdAt: string
+  user: {
+    id: number
+    image: string
+    name: string
+  }
+  category: {
+    id: number
+    name: string
+  }
+  products: [
+    {
+      id: string
+      image: string
+      name: string
+      price: number
+    },
+  ]
+}
+const fontStyle = { fontSize: 12, fontWeight: 'bold', ml: 0.5 }
+
+const PostDetail = () => {
+  const { id } = useParams<{ id: string }>()
+  const [anchorElUser, setAnchorElUser] = useState<null | HTMLElement>(null)
+  const handleOpenUserMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorElUser(event.currentTarget)
+  }
+  const handleCloseUserMenu = () => {
+    setAnchorElUser(null)
+  }
+
+  const [open, setOpen] = useState(false)
+  const handleOpen = () => {
+    setOpen(true)
+  }
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  const handleDelete = () => {
+    handleClose()
+  }
+
+  const { data, error } = useSWR(id ? getPostByIdUrl(id) : null, fetcher)
+
+  if (error) return <Error />
+  if (!data) return <Loading />
+
+  const post: Post = camelcaseKeys(data)
+
+  return (
+    <>
+      <NavigationHeader title="投稿" />
+      <Container
+        maxWidth="sm"
+        sx={{
+          mb: 11,
+          px: 0,
+        }}
+      >
+        <Box sx={{ width: '100%', aspectRatio: '1 / 0.8', mb: 2.5 }}>
+          <Image
+            src={post.image}
+            alt={post.user.name}
+            width={300}
+            height={300}
+            style={{ width: '100%', height: '100%' }}
+          />
+        </Box>
+        <Box
+          sx={{
+            width: '91%',
+            m: '0 auto',
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Box sx={{ display: 'flex', mb: 2 }}>
+              <Avatar
+                src={post.user.image}
+                alt={post.user.name}
+                sx={{ mr: 1.5 }}
+              />
+              <Box>
+                <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
+                  {post.user.name}
+                </Typography>
+                <Typography sx={{ color: '#666666', fontSize: 13 }}>
+                  {post.createdAt}
+                </Typography>
+              </Box>
+            </Box>
+
+            <Box sx={{ flexGrow: 0 }}>
+              <Tooltip title="メニューを開く">
+                <IconButton
+                  size="small"
+                  sx={{ mb: 2 }}
+                  onClick={handleOpenUserMenu}
+                >
+                  <MoreVertIcon />
+                </IconButton>
+              </Tooltip>
+              <Paper>
+                <Menu
+                  sx={{ mt: '40px' }}
+                  id="menu-appbar"
+                  anchorEl={anchorElUser}
+                  anchorOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right',
+                  }}
+                  keepMounted
+                  transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right',
+                  }}
+                  open={Boolean(anchorElUser)}
+                  onClose={handleCloseUserMenu}
+                >
+                  <Link href="/privacy">
+                    <MenuItem
+                      sx={{
+                        px: 1.5,
+                        color: '#1E90FF',
+                        borderBottom: '1px solid #ddd',
+                      }}
+                    >
+                      <EditOutlinedIcon />
+                      <Typography sx={fontStyle}>投稿を編集</Typography>
+                    </MenuItem>
+                  </Link>
+                  <MenuItem
+                    sx={{
+                      px: 1.5,
+                      color: 'red',
+                    }}
+                    onClick={() => {
+                      handleOpen()
+                      handleCloseUserMenu()
+                    }}
+                  >
+                    <DeleteOutlineOutlinedIcon />
+                    <Typography sx={fontStyle}>投稿を削除</Typography>
+                  </MenuItem>
+                  <Dialog
+                    open={open}
+                    onClose={handleClose}
+                    aria-labelledby="alert-dialog-title"
+                    aria-describedby="alert-dialog-description"
+                  >
+                    <DialogContent
+                      sx={{
+                        width: 230,
+                        pb: 1.5,
+                        textAlign: 'center',
+                        borderBottom: '1px solid #ddd',
+                      }}
+                    >
+                      <Typography sx={{ fontSize: 13.5, fontWeight: 'bold' }}>
+                        本当に投稿を削除してもよろしいですか？
+                      </Typography>
+                    </DialogContent>
+                    <DialogActions
+                      sx={{ height: 38, justifyContent: 'center' }}
+                    >
+                      <Button
+                        sx={{ fontSize: 12, width: '50%' }}
+                        onClick={handleClose}
+                        color="primary"
+                      >
+                        キャンセル
+                      </Button>
+                      <Button
+                        onClick={handleDelete}
+                        sx={{ fontSize: 12, width: '50%' }}
+                        color="error"
+                      >
+                        削除
+                      </Button>
+                    </DialogActions>
+                  </Dialog>
+                </Menu>
+              </Paper>
+            </Box>
+          </Box>
+          <Typography variant="body2" sx={{ mb: 1 }}>
+            {post.content}
+          </Typography>
+          <Typography variant="body2" sx={{ mb: 3, color: '#666666' }}>
+            {post.category.name}
+          </Typography>
+          <Typography variant="body2" sx={{ mb: 2, fontWeight: 'bold' }}>
+            おすすめ商品
+          </Typography>
+          <Grid container spacing={2} sx={{ mb: 5 }}>
+            {post.products &&
+              post.products.map((product) => (
+                <Grid
+                  size={{ xs: 6, sm: 4 }}
+                  key={product.id}
+                  sx={{ cursor: 'pointer' }}
+                >
+                  <ProductCard
+                    id={product.id}
+                    name={product.name}
+                    price={product.price}
+                    image={product.image}
+                    selected={false}
+                    deletable={false}
+                  />
+                </Grid>
+              ))}
+          </Grid>
+        </Box>
+      </Container>
+    </>
+  )
+}
+
+export default PostDetail

--- a/frontend/src/utils/urls.ts
+++ b/frontend/src/utils/urls.ts
@@ -16,3 +16,6 @@ export const searchProductsUrl = `${HOST_API_URL}/products/search?`
 
 // 投稿用URL（POST）
 export const createPostUrl = `${HOST_API_URL}/posts`
+
+// 投稿取得URL（GET）
+export const getPostByIdUrl = (id: string) => `${HOST_API_URL}/posts/${id}`


### PR DESCRIPTION
# 概要
投稿詳細画面の作成
# 再現手順
1. 投稿詳細画面(`http://localhost:3001/posts/1`)に遷移
2. 投稿した画像、内容、投稿日、関連するユーザー、カテゴリー、商品のデータが表示される
# 期待する動作
投稿詳細画面(`http://localhost:3001/posts/1`)に遷移すると、投稿したの画像、内容、投稿日、関連するユーザー、カテゴリー、商品のデータが表示されること。