### PR TITLE
新着投稿画面の作成

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@mui/material-nextjs": "^6.1.2",
         "axios": "^1.7.7",
         "camelcase-keys": "^9.1.3",
+        "framer-motion": "^11.11.17",
         "i": "^0.3.7",
         "next": "14.2.13",
         "next-auth": "^4.24.8",
@@ -24,6 +25,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.53.1",
+        "react-intersection-observer": "^9.13.1",
         "swr": "^2.2.5",
         "zod": "^3.23.8"
       },
@@ -3345,6 +3347,31 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.11.17",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.11.17.tgz",
+      "integrity": "sha512-O8QzvoKiuzI5HSAHbcYuL6xU+ZLXbrH7C8Akaato4JzQbX2ULNeniqC2Vo5eiCtFktX9XsJ+7nUhxcl2E2IjpA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {
@@ -8061,6 +8088,21 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.13.1.tgz",
+      "integrity": "sha512-tSzDaTy0qwNPLJHg8XZhlyHTgGW6drFKTtvjdL+p6um12rcnp8Z5XstE+QNBJ7c64n5o0Lj4ilUleA41bmDoMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@mui/material-nextjs": "^6.1.2",
     "axios": "^1.7.7",
     "camelcase-keys": "^9.1.3",
+    "framer-motion": "^11.11.17",
     "i": "^0.3.7",
     "next": "14.2.13",
     "next-auth": "^4.24.8",
@@ -26,6 +27,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.53.1",
+    "react-intersection-observer": "^9.13.1",
     "swr": "^2.2.5",
     "zod": "^3.23.8"
   },

--- a/frontend/src/app/components/Home.tsx
+++ b/frontend/src/app/components/Home.tsx
@@ -1,27 +1,63 @@
 'use client'
 
-import { useSession } from 'next-auth/react'
-import useSWR from 'swr'
-import { fetcher } from '@/utils/fetcher'
-import { apiCheckUrl } from '@/utils/urls'
+import { Tab, Tabs, Box } from '@mui/material'
+import { useState } from 'react'
+import HomePosts from './HomePosts'
+import { newPostsUrl } from '@/utils/urls'
+
+interface TabPanelProps {
+  children?: React.ReactNode
+  index: number
+  value: number
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props
+
+  return (
+    <Box
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 1 }}>{children}</Box>}
+    </Box>
+  )
+}
 
 const Home = () => {
-  const { data, error } = useSWR(apiCheckUrl, fetcher)
-  const { data: session } = useSession()
+  const [value, setValue] = useState(0)
 
-  if (error) return <div>An error has occurred.</div>
-  if (!data) return <div>Loading...</div>
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue)
+  }
 
   return (
     <>
-      <div>{data.message}</div>
-      <div>
-        {session && session.user && (
-          <div>
-            <p>Image: {session.user.image}</p>
-          </div>
-        )}
-      </div>
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Tabs
+          value={value}
+          onChange={handleChange}
+          sx={{
+            width: '100%',
+            maxWidth: 720,
+          }}
+        >
+          <Tab label="新着" />
+          <Tab label="おすすめ" />
+        </Tabs>
+      </Box>
+
+      <Box sx={{ borderBottom: '1px solid #999999', mb: 3 }} />
+
+      <TabPanel value={value} index={0}>
+        <HomePosts url={newPostsUrl} />
+      </TabPanel>
+      <TabPanel value={value} index={1}>
+        <HomePosts url="" />
+      </TabPanel>
     </>
   )
 }

--- a/frontend/src/app/components/HomePosts.tsx
+++ b/frontend/src/app/components/HomePosts.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { Box } from '@mui/material'
+import Grid from '@mui/material/Grid2'
+import camelcaseKeys from 'camelcase-keys'
+import { useEffect } from 'react'
+import { useInView } from 'react-intersection-observer'
+import useSWRInfinite from 'swr/infinite'
+import Error from './Error'
+import Loading from './Loading'
+import PostCard from './PostCard'
+import { fetcher, getKey } from '@/utils/fetcher'
+
+type HomePostsProps = {
+  url: string
+}
+
+type PostProps = {
+  id: number
+  image: string
+  content: string
+  createdAt: string
+  user: {
+    id: number
+    name: string
+    image: string
+  }
+}
+
+const HomePosts = ({ url }: HomePostsProps) => {
+  const { data, error, size, setSize, isValidating } = useSWRInfinite(
+    (pageIndex, previousPageData) => getKey(pageIndex, previousPageData, url),
+    fetcher,
+  )
+
+  const { ref, inView } = useInView()
+
+  useEffect(() => {
+    if (
+      !isValidating &&
+      inView &&
+      !(data && data[data.length - 1].length < 10)
+    ) {
+      setSize(size + 1)
+    }
+  }, [isValidating, inView, data, size, setSize])
+
+  if (error) return <Error />
+
+  const posts = data ? camelcaseKeys(data.flat()) : []
+
+  return (
+    <Box sx={{ maxWidth: 720, width: '80%', mx: 'auto', mb: 11 }}>
+      <Grid container spacing={5}>
+        {posts &&
+          posts.map((post: PostProps) => (
+            <Grid
+              key={post.id}
+              size={{ xs: 12, sm: 6 }}
+              sx={{ cursor: 'pointer' }}
+            >
+              <PostCard
+                id={post.id}
+                image={post.image}
+                content={post.content}
+                createdAt={post.createdAt}
+                userId={post.user.id}
+                userName={post.user.name}
+                userImage={post.user.image}
+              />
+            </Grid>
+          ))}
+      </Grid>
+      {!isValidating ? <Box ref={ref} /> : <Loading height="" />}
+    </Box>
+  )
+}
+
+export default HomePosts

--- a/frontend/src/app/components/Loading.tsx
+++ b/frontend/src/app/components/Loading.tsx
@@ -1,14 +1,22 @@
 import { Box } from '@mui/material'
 import Image from 'next/image'
 
-const Loading = () => {
+type LoadingProps = {
+  align?: 'center' | 'top'
+  height?: string | number
+}
+
+const Loading = ({
+  align = 'center',
+  height = 'calc(100vh - 64px)',
+}: LoadingProps) => {
   return (
     <Box
       sx={{
         display: 'flex',
         justifyContent: 'center',
-        alignItems: 'center',
-        height: 'calc(100vh - 64px)',
+        alignItems: align,
+        height: height,
       }}
     >
       <Image src="/loading.svg" alt="Loading..." width={90} height={90}></Image>

--- a/frontend/src/app/components/PostCard.tsx
+++ b/frontend/src/app/components/PostCard.tsx
@@ -1,0 +1,144 @@
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
+import FavoriteIcon from '@mui/icons-material/Favorite'
+import FavoriteBorderOutlinedIcon from '@mui/icons-material/FavoriteBorderOutlined'
+import ShareIcon from '@mui/icons-material/Share'
+import {
+  Card,
+  CardContent,
+  CardActions,
+  Typography,
+  IconButton,
+  Avatar,
+  Box,
+} from '@mui/material'
+import { motion } from 'framer-motion'
+import Image from 'next/image'
+import Link from 'next/link'
+import React, { useState } from 'react'
+
+type PostCardProps = {
+  id: number
+  image: string
+  content: string
+  createdAt: string
+  userId: number
+  userName: string
+  userImage: string
+}
+
+const PostCard = (props: PostCardProps) => {
+  const [isLike, setIsLike] = useState(false)
+
+  const handleLike = () => {
+    setIsLike(!isLike)
+  }
+  const handleShare = () => {}
+
+  return (
+    <Card sx={{ position: 'relative' }}>
+      <Link href={`/posts/${props.id}`}>
+        <Box
+          sx={{
+            position: 'relative',
+            width: '100%',
+            height: 210,
+          }}
+        >
+          <Image
+            src={props.image}
+            alt=""
+            fill
+            style={{ width: '100%', height: '100%' }}
+          />
+        </Box>
+      </Link>
+
+      <Link href={`/my-page/${props.userId}`}>
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 165,
+            left: 10,
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <Avatar
+            src={props.userImage}
+            sx={{ width: 33, height: 33, mr: 1, border: '1px, solid, white' }}
+          ></Avatar>
+          <Typography
+            sx={{
+              color: '#FFFFFF',
+              fontWeight: 'bold',
+              fontSize: 13,
+            }}
+          >
+            {props.userName}
+          </Typography>
+        </Box>
+      </Link>
+
+      <Link href={`/posts/${props.id}`}>
+        <CardContent sx={{ height: 80, pt: 1.3 }}>
+          <Typography variant="caption" sx={{ color: '#666666' }}>
+            {props.createdAt}
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{
+              display: '-webkit-box',
+              overflow: 'hidden',
+              WebkitBoxOrient: 'vertical',
+              WebkitLineClamp: 2,
+              mt: 0.5,
+            }}
+          >
+            {props.content}
+          </Typography>
+        </CardContent>
+      </Link>
+
+      <CardActions
+        disableSpacing
+        sx={{ display: 'flex', justifyContent: 'space-between' }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', color: '#666666' }}>
+          <IconButton sx={{ width: 25 }} onClick={handleLike}>
+            <motion.div
+              whileTap={{
+                scale: 1.6,
+              }}
+              initial={{ scale: 1 }}
+              style={{ display: 'flex', alignItems: 'center' }}
+            >
+              {isLike ? (
+                <FavoriteIcon sx={{ color: 'red', fontSize: 21.7 }} />
+              ) : (
+                <FavoriteBorderOutlinedIcon sx={{ fontSize: 21.7 }} />
+              )}
+            </motion.div>
+          </IconButton>
+
+          <Typography component="span" variant="body2" sx={{ mr: 1.2 }}>
+            {100}
+          </Typography>
+
+          <Link href={`/posts/${props.id}`}>
+            <IconButton sx={{ width: 25 }}>
+              <ChatBubbleOutlineIcon fontSize="small" />
+            </IconButton>
+            <Typography component="span" variant="body2">
+              {100}
+            </Typography>
+          </Link>
+        </Box>
+        <IconButton onClick={handleShare}>
+          <ShareIcon fontSize="small" />
+        </IconButton>
+      </CardActions>
+    </Card>
+  )
+}
+
+export default PostCard

--- a/frontend/src/app/posts/search/page.tsx
+++ b/frontend/src/app/posts/search/page.tsx
@@ -115,7 +115,7 @@ const Search = () => {
             {errorMessage && <ValidationMessage message={errorMessage} />}
 
             {isLoading ? (
-              <Loading />
+              <Loading align="top" />
             ) : keyword && products.length === 0 ? (
               <Typography variant="body2" sx={{ mt: 2, textAlign: 'center' }}>
                 検索結果が見つかりませんでした。

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -47,6 +47,27 @@ const theme = createTheme({
         },
       },
     },
+    MuiTabs: {
+      styleOverrides: {
+        indicator: {
+          backgroundColor: 'black',
+          height: 1,
+        },
+      },
+    },
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          color: '#999999',
+          fontSize: 13.5,
+          width: '50%',
+          fontWeight: 'bold',
+          '&.Mui-selected': {
+            color: 'black',
+          },
+        },
+      },
+    },
   },
 })
 

--- a/frontend/src/utils/fetcher.ts
+++ b/frontend/src/utils/fetcher.ts
@@ -12,3 +12,12 @@ export const fetcher = (url: string, token?: string) =>
       console.log(e)
       throw e
     })
+
+export const getKey = <T>(
+  pageIndex: number,
+  previousPageData: T[],
+  url: string,
+) => {
+  if (previousPageData && !previousPageData.length) return null
+  return `${url}?page=${pageIndex + 1}`
+}

--- a/frontend/src/utils/urls.ts
+++ b/frontend/src/utils/urls.ts
@@ -28,3 +28,6 @@ export const updatePostUrl = (id: string) => `${HOST_API_URL}/posts/${id}`
 
 // 投稿削除用URL（DELETE）
 export const deletePostUrl = (id: string) => `${HOST_API_URL}/posts/${id}`
+
+// 新着投稿取得用URL（GET）
+export const newPostsUrl = `${HOST_API_URL}/posts/new_posts`


### PR DESCRIPTION
# 概要
新着投稿画面の作成
# 再現手順
1. Topページ(`http://localhost:3001`)に遷移
2. 新着、おすすめタブが表示される
3. 新着を選択
4. 投稿カードが10件表示される
5. 一番下までスクロールする
6. 次のページを読み込み、10件投稿が表示
7. 投稿カードをクリック
8. 投稿詳細画面(`http://localhost:3001/posts/:id`)が表示される
# 期待する動作
Topページ(`http://localhost:3001`)に遷移すると、新着、おすすめタブが表示され、新着を選択すると、投稿カードが10件表示され、一番下までスクロールすると、次のページを読み込み、10件投稿が表示されること。
投稿カードをクリックすると、投稿詳細画面(`http://localhost:3001/posts/:id`)が表示されること。