### PR TITLE
投稿検索機能の作成

### DIFF
--- a/backend/app/serializers/post_card_serializer.rb
+++ b/backend/app/serializers/post_card_serializer.rb
@@ -1,4 +1,4 @@
-class NewPostSerializer < ApplicationSerializer
+class PostCardSerializer < ApplicationSerializer
   include Rails.application.routes.url_helpers
 
   attributes :id, :image, :content, :created_at

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       resources :posts, only: [:create, :show, :edit, :update, :destroy] do
         collection do
           get "new_posts"
+          get "search"
         end
       end
       resources :categories, only: [:index]


### PR DESCRIPTION
# 概要
投稿検索機能の作成
# 再現手順
キーワード検索
1. `http://localhost:3000/api/v1/posts/search?search_term=スポーツ&page=1`にGETリクエスト
2. 投稿内容がスポーツまたは、カテゴリーがスポーツの投稿と関連するユーザーのデータを取得

カテゴリー検索
1. `http://localhost:3000/api/v1/posts/search?category_id=1&page=1`にGETリクエスト
2. カテゴリーIDが1の投稿と関連するユーザーのデータを取得
# 期待する動作
キーワード検索
・`http://localhost:3000/api/v1/posts/search?search_term=スポーツ&page=1`にGETリクエストすると、投稿内容がスポーツまたは、カテゴリーがスポーツの投稿と関連するユーザーのデータを取得されること。

カテゴリー検索
・`http://localhost:3000/api/v1/posts/search?category_id=1&page=1`にGETリクエストすると、カテゴリーIDが1の投稿と関連するユーザーのデータを取得されること。
