### PR TITLE
商品詳細画面の作成

### DIFF
--- a/backend/app/serializers/product_serializer.rb
+++ b/backend/app/serializers/product_serializer.rb
@@ -8,4 +8,12 @@ class ProductSerializer < ApplicationSerializer
   def image
     object.image.attached? ? rails_blob_url(object.image) : nil
   end
+
+  def details
+    object.details.gsub('。', "。\n")
+  end
+
+  def price
+    object.price.to_i.to_fs(:delimited)
+  end
 end

--- a/frontend/src/app/components/Header.tsx
+++ b/frontend/src/app/components/Header.tsx
@@ -42,7 +42,8 @@ const Header = () => {
 
   const hiddenPathnames = ['/posts/search', '/search/search-results']
   const pathname = usePathname()
-  const isPathMatch = /\/posts\/\d+$/.test(pathname)
+  const isPathMatch =
+    /\/posts\/\d+$/.test(pathname) || /\/product\/\d+$/.test(pathname)
 
   if (isPathMatch || hiddenPathnames.includes(pathname)) return <></>
 

--- a/frontend/src/app/posts/[id]/page.tsx
+++ b/frontend/src/app/posts/[id]/page.tsx
@@ -286,14 +286,16 @@ const PostDetail = () => {
                     key={product.id}
                     sx={{ cursor: 'pointer' }}
                   >
-                    <ProductCard
-                      id={product.id}
-                      name={product.name}
-                      price={product.price}
-                      image={product.image}
-                      selected={false}
-                      deletable={false}
-                    />
+                    <Link href={`/product/${product.id}`}>
+                      <ProductCard
+                        id={product.id}
+                        name={product.name}
+                        price={product.price}
+                        image={product.image}
+                        selected={false}
+                        deletable={false}
+                      />
+                    </Link>
                   </Grid>
                 ))}
             </Grid>

--- a/frontend/src/app/product/[id]/page.tsx
+++ b/frontend/src/app/product/[id]/page.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import { Box, Typography, Container, Button } from '@mui/material'
+import Grid from '@mui/material/Grid2'
+import camelcaseKeys from 'camelcase-keys'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import useSWR from 'swr'
+import Error from '@/app/components/Error'
+import Loading from '@/app/components/Loading'
+import NavigationHeader from '@/app/components/NavigationHeader'
+import { fetcher } from '@/utils/fetcher'
+import { getProductByIdUrl } from '@/utils/urls'
+
+type Product = {
+  id: number
+  image: string
+  name: string
+  details: string
+  price: number
+  productUrl: string
+  posts: [
+    {
+      id: string
+      image: string
+    },
+  ]
+}
+
+const ProductDetail = () => {
+  const { id } = useParams<{ id: string }>()
+  const { data, error } = useSWR(getProductByIdUrl(id), fetcher)
+
+  if (error) return <Error />
+  if (!data) return <Loading />
+
+  const product: Product = camelcaseKeys(data)
+
+  return (
+    <>
+      <NavigationHeader title="商品" />
+      <Container
+        maxWidth="sm"
+        sx={{
+          mb: 11,
+          px: 0,
+        }}
+      >
+        <Box sx={{ width: '100%', aspectRatio: '1 / 0.7', mb: 3 }}>
+          <Image
+            src={product.image}
+            alt={product.name}
+            width={300}
+            height={300}
+            style={{ width: '100%', height: '100%' }}
+          />
+        </Box>
+        <Box sx={{ width: '94%', m: '0 auto' }}>
+          <Typography variant="body2" sx={{ fontWeight: 'bold', mb: 0.7 }}>
+            {product.name}
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{ fontWeight: 'bold', color: 'red', mb: 0.8 }}
+          >
+            ￥{product.price}
+          </Typography>
+          <Typography variant="body2" sx={{ mb: 5, whiteSpace: 'pre-line' }}>
+            {product.details}
+          </Typography>
+          <Button
+            variant="contained"
+            startIcon={<OpenInNewIcon />}
+            href={product.productUrl}
+            target="_brank"
+            rel="noopener noreferrer"
+            sx={{
+              backgroundColor: 'black',
+              color: 'white',
+              width: '100%',
+              mb: 5,
+            }}
+          >
+            <Typography variant="body2"> 購入サイトへ</Typography>
+          </Button>
+          <Typography variant="body2" sx={{ fontWeight: 'bold', mb: 2 }}>
+            関連する投稿
+          </Typography>
+          <Grid container spacing={3}>
+            {product.posts &&
+              product.posts.map((post) => (
+                <Grid
+                  key={post.id}
+                  size={{ xs: 6, sm: 4 }}
+                  sx={{ cursor: 'pointer' }}
+                >
+                  <Link href={`/posts/${post.id}`}>
+                    <Box
+                      sx={{ position: 'relative', width: '100%', height: 150 }}
+                    >
+                      <Image
+                        src={post.image}
+                        alt={post.id}
+                        fill
+                        style={{
+                          width: '100%',
+                          height: '100%',
+                          objectFit: 'cover',
+                          borderRadius: 3,
+                        }}
+                      />
+                    </Box>
+                  </Link>
+                </Grid>
+              ))}
+          </Grid>
+        </Box>
+      </Container>
+    </>
+  )
+}
+
+export default ProductDetail

--- a/frontend/src/utils/urls.ts
+++ b/frontend/src/utils/urls.ts
@@ -35,3 +35,7 @@ export const newPostsUrl = `${HOST_API_URL}/posts/new_posts`
 
 // 投稿検索用URL（GET）
 export const searchPostsUrl = `${HOST_API_URL}/posts/search`
+
+// 商品取得URL（GET）
+export const getProductByIdUrl = (id: string) =>
+  `${HOST_API_URL}/products/${id}`


### PR DESCRIPTION
# 概要
商品詳細画面の作成
# 再現手順
1. 投稿詳細画面(`http://localhost:3001/posts/:id`)に遷移
2. おすすめ商品に表示されている商品をクリック
3. 商品詳細画面(`http://localhost:3001/product/:id`)に遷移
4. 商品画像、商品名、値段、商品説明、商品が使われている投稿が表示される
5. 関連する投稿の投稿画像をクリック
6. 投稿詳細画面(`http://localhost:3001/posts/:id`)に遷移する
# 期待する動作
投稿詳細画面(`http://localhost:3001/posts/:id`)に遷移し、おすすめ商品に表示されている商品をクリックすると、商品詳細画面(`http://localhost:3001/product/:id`)に遷移され、商品画像、商品名、値段、商品説明、商品が使われている投稿が表示されること。
関連する投稿の投稿画像をクリックすると、投稿詳細画面(`http://localhost:3001/posts/:id`)に遷移すること。