### PR TITLE
マイページ詳細画面の作成

### DIFF
--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -101,6 +101,11 @@ class Api::V1::PostsController < ApplicationController
     render json: posts.page(params[:page]).per(10), each_serializer: PostCardSerializer, status: :ok
   end
 
+  def user_posts
+    posts = User.includes(:posts).find(params[:id]).posts
+    render json: posts, each_serializer: UserPostSerializer, status: :ok
+  end
+
   private
 
   # 商品追加処理

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,11 @@
 require 'open-uri'
 
 class Api::V1::UsersController < ApplicationController
+  def show
+    user = User.find(params[:id])
+    render json: user, serializer: ShowUserSerializer, status: :ok
+  end
+
   def create
     user = User.find_or_create_by(email: user_params[:email], provider: user_params[:provider]) do |new_user|
       new_user.name = user_params[:name]

--- a/backend/app/serializers/show_user_serializer.rb
+++ b/backend/app/serializers/show_user_serializer.rb
@@ -1,0 +1,9 @@
+class ShowUserSerializer < ApplicationSerializer
+  include Rails.application.routes.url_helpers
+
+  attributes :id, :name, :image, :bio
+
+  def image
+    object.image.attached? ? rails_blob_url(object.image, host: UrlHost.host) : nil
+  end
+end

--- a/backend/app/serializers/user_post_serializer.rb
+++ b/backend/app/serializers/user_post_serializer.rb
@@ -1,0 +1,9 @@
+class UserPostSerializer < ApplicationSerializer
+  include Rails.application.routes.url_helpers
+
+  attributes :id, :image
+
+  def image
+    object.image.attached? ? rails_blob_url(object.image) : nil
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,6 +6,11 @@ Rails.application.routes.draw do
     namespace :v1 do
       post "auth/:provider/callback", to: "users#create"
       get "api_check", to: "api_check#index"
+      resources :users, only: [:show, :update] do
+        member do
+          get "user_posts", to: "posts#user_posts"
+        end
+      end
       resources :posts, only: [:create, :show, :edit, :update, :destroy] do
         collection do
           get "new_posts"

--- a/frontend/src/app/components/Footer.tsx
+++ b/frontend/src/app/components/Footer.tsx
@@ -74,7 +74,7 @@ const Footer = () => {
               checkUserLogin('/notifications')
               break
             case 4:
-              checkUserLogin('/my-page')
+              checkUserLogin(`/my-page/${session?.user.id}`)
               break
           }
         }}

--- a/frontend/src/app/components/MyPagePosts.tsx
+++ b/frontend/src/app/components/MyPagePosts.tsx
@@ -1,0 +1,50 @@
+import { Box } from '@mui/material'
+import Grid from '@mui/material/Grid2'
+import Image from 'next/image'
+import Link from 'next/link'
+import useSWR from 'swr'
+import Error from './Error'
+import Loading from './Loading'
+import { fetcher } from '@/utils/fetcher'
+
+type MyPagePostsProps = {
+  apiUrl: string
+}
+
+type userPosts = {
+  id: number
+  image: string
+}
+
+const MyPagePosts = ({ apiUrl }: MyPagePostsProps) => {
+  const { data, error } = useSWR<userPosts[]>(apiUrl, fetcher)
+
+  if (error) return <Error />
+  if (!data) return <Loading />
+
+  return (
+    <Grid container spacing={2}>
+      {data &&
+        data.map((post) => (
+          <Grid
+            key={post.id}
+            size={{ xs: 6, sm: 4 }}
+            sx={{ cursor: 'pointer' }}
+          >
+            <Link href={`/posts/${post.id}`}>
+              <Box sx={{ position: 'relative', width: '100%', height: 150 }}>
+                <Image
+                  src={post.image}
+                  alt=""
+                  fill
+                  style={{ width: '100%', height: '100%', borderRadius: 3 }}
+                />
+              </Box>
+            </Link>
+          </Grid>
+        ))}
+    </Grid>
+  )
+}
+
+export default MyPagePosts

--- a/frontend/src/app/my-page/[id]/page.tsx
+++ b/frontend/src/app/my-page/[id]/page.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import {
+  Typography,
+  Avatar,
+  Container,
+  Box,
+  Button,
+  Tab,
+  Tabs,
+} from '@mui/material'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+import { useState } from 'react'
+import useSWR from 'swr'
+import MyPagePosts from '../../components/MyPagePosts'
+import Error from '@/app/components/Error'
+import Loading from '@/app/components/Loading'
+import { fetcher } from '@/utils/fetcher'
+import { getUserByIdUrl, getUserPostsUrl } from '@/utils/urls'
+
+interface TabPanelProps {
+  children?: React.ReactNode
+  index: number
+  value: number
+}
+
+type user = {
+  id: number
+  name: string
+  image: string
+  bio: string
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props
+
+  return (
+    <Box
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 1 }}>{children}</Box>}
+    </Box>
+  )
+}
+const MyPage = () => {
+  const [value, setValue] = useState(0)
+  const { id } = useParams<{ id: string }>()
+  const { data: session } = useSession()
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue)
+  }
+  const { data, error } = useSWR<user>(getUserByIdUrl(id), fetcher)
+
+  if (error) return <Error />
+  if (!data) return <Loading />
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 5, mb: 10 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+        <Avatar src={data.image} sx={{ width: 80, height: 80, mr: 2 }} />
+        <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
+          {data.name}
+        </Typography>
+      </Box>
+      <Box sx={{ display: 'flex', mb: 2 }}>
+        <Box>
+          <Typography
+            variant="body2"
+            component="span"
+            sx={{ fontWeight: 'bold', mr: 0.3 }}
+          >
+            {100}
+          </Typography>
+          <Typography
+            variant="body2"
+            component="span"
+            sx={{ color: '#666666', mr: 1 }}
+          >
+            フォロー中
+          </Typography>
+        </Box>
+        <Box>
+          <Typography
+            variant="body2"
+            component="span"
+            sx={{ fontWeight: 'bold', mr: 0.3 }}
+          >
+            {100}
+          </Typography>
+          <Typography
+            variant="body2"
+            component="span"
+            sx={{ color: '#666666' }}
+          >
+            フォロワー
+          </Typography>
+        </Box>
+      </Box>
+      <Typography variant="body2" sx={{ overflowWrap: 'break-word', mb: 3 }}>
+        {data.bio}
+      </Typography>
+      {Number(session?.user.id) == data.id ? (
+        <Link href="/my-page/edit">
+          <Button
+            variant="contained"
+            sx={{ width: '100%', backgroundColor: 'black', py: 1.1, mb: 3 }}
+          >
+            <Typography sx={{ color: 'white', fontSize: 12 }}>
+              プロフィールを編集
+            </Typography>
+          </Button>
+        </Link>
+      ) : (
+        session?.user && (
+          <Button
+            variant="contained"
+            sx={{ width: '100%', backgroundColor: 'black', py: 1.1, mb: 3 }}
+            // onClick={}
+          >
+            <Typography sx={{ color: 'white', fontSize: 12 }}>
+              フォロー
+            </Typography>
+          </Button>
+        )
+      )}
+      <Tabs value={value} onChange={handleChange}>
+        <Tab label="投稿" />
+        <Tab label="いいね" />
+      </Tabs>
+      <Box sx={{ borderBottom: '1px solid #999999', mb: 1 }} />
+
+      <TabPanel value={value} index={0}>
+        <MyPagePosts apiUrl={getUserPostsUrl(id)} />
+      </TabPanel>
+      <TabPanel value={value} index={1}>
+        <MyPagePosts apiUrl="" />
+      </TabPanel>
+    </Container>
+  )
+}
+
+export default MyPage

--- a/frontend/src/utils/urls.ts
+++ b/frontend/src/utils/urls.ts
@@ -39,3 +39,10 @@ export const searchPostsUrl = `${HOST_API_URL}/posts/search`
 // 商品取得URL（GET）
 export const getProductByIdUrl = (id: string) =>
   `${HOST_API_URL}/products/${id}`
+
+// ユーザー取得URL（GET）
+export const getUserByIdUrl = (id: string) => `${HOST_API_URL}/users/${id}`
+
+// ユーザー投稿URL（GET）
+export const getUserPostsUrl = (id: string) =>
+  `${HOST_API_URL}/users/${id}/user_posts`


### PR DESCRIPTION
# 概要
マイページ詳細画面の作成
# 再現手順
1. Top詳細画面(`http://localhost:3001`)に遷移
2. フッターのマイページをクリック
3. マイページ(`http://localhost:3001/my-page/:id`)に遷移
4. ユーザの画像、名前、自己紹介、投稿した画像一覧が表示
5. 投稿の画像をクリック
6. 投稿詳細画面(http://localhost:3001/posts/:id)に遷移
# 期待する動作
Top詳細画面(`http://localhost:3001`)に遷移し、フッターのマイページをクリックすると、マイページ(`http://localhost:3001/my-page/:id`)に遷移し、ユーザの画像、名前、自己紹介、投稿した画像一覧が表示されること。
投稿の画像をクリックすると、投稿詳細画面(http://localhost:3001/posts/:id)に遷移に遷移すること。