### PR TITLE
お知らせ機能の作成

### DIFF
--- a/backend/app/controllers/api/v1/notifications_controller.rb
+++ b/backend/app/controllers/api/v1/notifications_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::NotificationsController < ApplicationController
+  before_action :authenticate
+
+  def index
+    notifications = @current_user.notifications.includes(:notified_by)
+    render json: notifications, status: :ok
+  end
+
+  def update
+    notification = Notification.find(params[:id])
+    if notification.update(read: true)
+      head :ok
+    else
+      render json: { error: '通知の更新に失敗しました' }, status: :unprocessable_entity
+    end
+  end
+end

--- a/backend/app/models/comment.rb
+++ b/backend/app/models/comment.rb
@@ -24,4 +24,12 @@ class Comment < ApplicationRecord
   belongs_to :post
 
   validates :content, presence: true
+
+  after_create :create_notification
+
+  private
+
+  def create_notification
+    Notification.create_notification(post, post.user, user, :new_comment)
+  end
 end

--- a/backend/app/models/like.rb
+++ b/backend/app/models/like.rb
@@ -21,4 +21,12 @@
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :post
+
+  after_create :create_notification
+
+  private
+
+  def create_notification
+    Notification.create_notification(post, post.user, user, :new_like)
+  end
 end

--- a/backend/app/models/notification.rb
+++ b/backend/app/models/notification.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                :bigint           not null, primary key
+#  notification_type :integer          not null
+#  read              :boolean          default(FALSE), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  notified_by_id    :bigint           not null
+#  post_id           :bigint
+#  user_id           :bigint           not null
+#
+# Indexes
+#
+#  index_notifications_on_notified_by_id  (notified_by_id)
+#  index_notifications_on_post_id         (post_id)
+#  index_notifications_on_user_id         (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (notified_by_id => users.id)
+#  fk_rails_...  (post_id => posts.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Notification < ApplicationRecord
+  belongs_to :post, optional: true
+  belongs_to :user
+  belongs_to :notified_by, class_name: 'User'
+
+  enum :notification_type, { new_comment: 0, new_like: 1, new_follower: 2 }
+
+  def self.create_notification(post = nil, user, notified_by, notification_type)
+    # 同一ユーザーの場合は通知を作成しない
+    return if user == notified_by
+
+    create(post:, user:, notified_by:, notification_type:, read: false)
+  end
+end

--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -27,6 +27,7 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :users, through: :likes
   has_many :comments, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   validates :content, presence: true, length: { maximum: 500 }
 

--- a/backend/app/models/relationship.rb
+++ b/backend/app/models/relationship.rb
@@ -21,4 +21,12 @@
 class Relationship < ApplicationRecord
   belongs_to :follower, class_name: 'User'
   belongs_to :followed, class_name: 'User'
+
+  after_create :create_notification
+
+  private
+
+  def create_notification
+    Notification.create_notification(nil, follower, followed, :new_follower)
+  end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -28,6 +28,7 @@ class User < ApplicationRecord
                                    foreign_key: 'followed_id',
                                    dependent: :destroy,
                                    inverse_of: :followed
+  has_many :notifications, dependent: :destroy
 
   validates :name,      presence: true
   validates :email,     presence: true, uniqueness: true

--- a/backend/app/serializers/notification_serializer.rb
+++ b/backend/app/serializers/notification_serializer.rb
@@ -1,0 +1,47 @@
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                :bigint           not null, primary key
+#  notification_type :integer          not null
+#  read              :boolean          default(FALSE), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  notified_by_id    :bigint           not null
+#  post_id           :bigint
+#  user_id           :bigint           not null
+#
+# Indexes
+#
+#  index_notifications_on_notified_by_id  (notified_by_id)
+#  index_notifications_on_post_id         (post_id)
+#  index_notifications_on_user_id         (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (notified_by_id => users.id)
+#  fk_rails_...  (post_id => posts.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class NotificationSerializer < ApplicationSerializer
+  attributes :id, :post_id, :user_id, :notification_type, :read, :created_at
+
+  belongs_to :notified_by, serializer: NotificationUserSerializer
+
+  def notification_type
+    case object.notification_type
+    when 'new_comment'
+      'コメント'
+    when 'new_like'
+      'いいね'
+    when 'new_follower'
+      'フォロー'
+    else
+      ''
+    end
+  end
+
+  def created_at
+    format_created_at(object.created_at)
+  end
+end

--- a/backend/app/serializers/notification_user_serializer.rb
+++ b/backend/app/serializers/notification_user_serializer.rb
@@ -1,0 +1,9 @@
+class NotificationUserSerializer < ApplicationSerializer
+  include Rails.application.routes.url_helpers
+
+  attributes :id, :image, :name
+
+  def image
+    object.image.attached? ? rails_blob_url(object.image) : nil
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
           get "search"
         end
       end
+      resources :notifications, only: [:index, :update]
     end
   end
 end

--- a/backend/db/migrate/20241204150630_create_notifications.rb
+++ b/backend/db/migrate/20241204150630_create_notifications.rb
@@ -1,0 +1,13 @@
+class CreateNotifications < ActiveRecord::Migration[7.2]
+  def change
+    create_table :notifications do |t|
+      t.references :post, null: true, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.references :notified_by, null: false, foreign_key: { to_table: :users }
+      t.integer :notification_type, null: false 
+      t.boolean :read, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_01_163039) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_04_150630) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -68,6 +68,19 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_01_163039) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "post_id"
+    t.bigint "user_id", null: false
+    t.bigint "notified_by_id", null: false
+    t.integer "notification_type", null: false
+    t.boolean "read", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notified_by_id"], name: "index_notifications_on_notified_by_id"
+    t.index ["post_id"], name: "index_notifications_on_post_id"
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
   create_table "post_products", force: :cascade do |t|
     t.bigint "post_id", null: false
     t.bigint "product_id", null: false
@@ -123,6 +136,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_01_163039) do
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "notifications", "posts"
+  add_foreign_key "notifications", "users"
+  add_foreign_key "notifications", "users", column: "notified_by_id"
   add_foreign_key "post_products", "posts"
   add_foreign_key "post_products", "products"
   add_foreign_key "posts", "categories"


### PR DESCRIPTION
# 概要
お知らせ機能の作成
# 再現手順
取得
1. `http://localhost:3000/api/v1/notifications`にGETリクエストを送信
2. ログインユーザーのお知らせ一覧が取得される

登録
1. ログインユーザーの投稿にいいね、コメント、ログインユーザーがフォローされるとお知らせがテーブルに登録される

更新
1. `http://localhost:3000/api/v1/notifications/:id`にPOSTリクエストを送信
2. 対象データのreadカラムがtrueに更新される
# 期待する動作
取得
・`http://localhost:3000/api/v1/notifications`にGETリクエストを送信すると、ログインユーザーのお知らせ一覧が取得されること。

登録
・ログインユーザーの投稿にいいね、コメント、ログインユーザーがフォローされるとお知らせがテーブルに登録されること。

更新
・`http://localhost:3000/api/v1/notifications/:id`にPOSTリクエストを送信すると、 対象データのreadカラムがtrueに更新されること。

