### PR TITLE
お知らせ画面の作成

### DIFF
--- a/backend/app/controllers/api/v1/notifications_controller.rb
+++ b/backend/app/controllers/api/v1/notifications_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::NotificationsController < ApplicationController
-  before_action :authenticate
+  before_action :authenticate, only: [:index, :update]
 
   def index
     notifications = @current_user.notifications.includes(:notified_by)
@@ -7,7 +7,7 @@ class Api::V1::NotificationsController < ApplicationController
   end
 
   def update
-    notification = Notification.find(params[:id])
+    notification = @current_user.notifications.find(params[:id])
     if notification.update(read: true)
       head :ok
     else

--- a/backend/app/serializers/notification_user_serializer.rb
+++ b/backend/app/serializers/notification_user_serializer.rb
@@ -4,6 +4,6 @@ class NotificationUserSerializer < ApplicationSerializer
   attributes :id, :image, :name
 
   def image
-    object.image.attached? ? rails_blob_url(object.image) : nil
+    object.image.attached? ? rails_blob_url(object.image, host: UrlHost.host) : nil
   end
 end

--- a/frontend/src/app/notifications/page.tsx
+++ b/frontend/src/app/notifications/page.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import {
+  Typography,
+  Avatar,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Divider,
+  Box,
+} from '@mui/material'
+import axios from 'axios'
+import camelcaseKeys from 'camelcase-keys'
+import Link from 'next/link'
+import { useSession } from 'next-auth/react'
+import useSWR, { mutate } from 'swr'
+import Error from '../components/Error'
+import Loading from '../components/Loading'
+import { fetcher } from '@/utils/fetcher'
+import { getNotificationUrl, updateNotificationUrl } from '@/utils/urls'
+
+type Notification = {
+  id: number
+  postId: number
+  userId: number
+  notificationType: string
+  read: boolean
+  createdAt: string
+  notifiedBy: {
+    id: number
+    image: string
+    name: string
+  }
+}
+
+const Notifications = () => {
+  const { data: session } = useSession()
+  const { data, error } = useSWR(getNotificationUrl, (url) =>
+    fetcher(url, session?.user?.token),
+  )
+
+  const handleSetNotificationRead = async (id: number) => {
+    try {
+      await axios.patch(updateNotificationUrl(id.toString()), null, {
+        headers: {
+          'auth-token': session?.user.token,
+        },
+      })
+      mutate([getNotificationUrl, session?.user?.token])
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  if (error) return <Error />
+  if (!data) return <Loading />
+
+  const notifications: Notification[] = camelcaseKeys(data)
+
+  return (
+    <List>
+      {notifications &&
+        notifications.map((notification) => (
+          <Box
+            key={notification.id}
+            sx={{
+              backgroundColor: notification.read ? 'none' : '#dceefb',
+            }}
+          >
+            <ListItem
+              alignItems="flex-start"
+              sx={{ width: '100%' }}
+              onClick={() => {
+                if (!notification.read) {
+                  handleSetNotificationRead(notification.id)
+                }
+              }}
+            >
+              <Link href={`my-page/${notification.notifiedBy.id}`}>
+                <ListItemAvatar>
+                  <Avatar
+                    alt={notification.notifiedBy.name}
+                    src={notification.notifiedBy.image}
+                  />
+                </ListItemAvatar>
+              </Link>
+              <Link
+                href={
+                  notification.postId
+                    ? `posts/${notification.postId}`
+                    : `my-page/${notification.userId}`
+                }
+              >
+                <ListItemText
+                  primary={
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        overflowWrap: 'break-word',
+                        mb: 0.2,
+                      }}
+                    >
+                      <Typography
+                        component="span"
+                        variant="body2"
+                        sx={{ fontWeight: 'bold' }}
+                      >
+                        {`${notification.notifiedBy.name}`}
+                      </Typography>
+                      さんが
+                      {notification.notificationType === 'フォロー'
+                        ? 'あなたをフォローしました。'
+                        : `あなたを投稿に${notification.notificationType}しました。`}
+                    </Typography>
+                  }
+                  secondary={
+                    <Typography sx={{ fontSize: 13 }}>
+                      {notification.createdAt}
+                    </Typography>
+                  }
+                />
+              </Link>
+            </ListItem>
+            <Divider
+              variant="inset"
+              component="li"
+              sx={{ m: 0, width: '100%' }}
+            />
+          </Box>
+        ))}
+    </List>
+  )
+}
+
+export default Notifications

--- a/frontend/src/utils/urls.ts
+++ b/frontend/src/utils/urls.ts
@@ -66,3 +66,10 @@ export const commentUrl = (id: string) => `${HOST_API_URL}/posts/${id}/comments`
 // フォローURL （POST, DELETE）
 export const followUrl = (id: string) =>
   `${HOST_API_URL}/users/${id}/relationships`
+
+// お知らせ取得URL（GET）
+export const getNotificationUrl = `${HOST_API_URL}/notifications`
+
+// お知らせ更新URL（PATCH）
+export const updateNotificationUrl = (id: string) =>
+  `${HOST_API_URL}/notifications/${id}`


### PR DESCRIPTION
# 概要
お知らせ画面の作成
# 再現手順
1. Top詳細画面(`http://localhost:3001`)に遷移
2. フッターのお知らせをクリック
3. お知らせ画面(`http://localhost:3001/notifications`)に遷移
4. お知らせ一覧が表示される
5. 既読していないお知らせの背景色は薄い青色で表示される
6. お知らせをクリック
7. いいね、コメントの場合は投稿詳細ページ(`http://localhost:3001/posts/:id`)、フォローの場合は`http://localhost:3001/my-page/:id`)に遷移し、既読していないお知らせの場合は背景色がなくなる
# 期待する動作
Top詳細画面(`http://localhost:3001`)に遷移し、フッターのお知らせをクリックすると、お知らせ画面(`http://localhost:3001/notifications`)に遷移し、お知らせ一覧が表示されること。
既読していないお知らせの背景色は薄い青色で表示され、お知らせをクリックすると、いいね、コメントの場合は投稿詳細ページ(`http://localhost:3001/posts/:id`)、フォローの場合は`http://localhost:3001/my-page/:id`)に遷移し、既読していないお知らせの場合は背景色がなくなること。
# 動作環境
ログイン済であること