### PR TITLE
usersテーブルの編集

### DIFF
--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -14,7 +14,6 @@
 #
 #  index_users_on_email               (email) UNIQUE
 #  index_users_on_email_and_provider  (email,provider) UNIQUE
-#  index_users_on_provider            (provider) UNIQUE
 #
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
@@ -34,7 +33,7 @@ class User < ApplicationRecord
   validates :email,     presence: true, uniqueness: true
   validates :image,     presence: true
   validates :bio,       length: { maximum: 200 }
-  validates :provider,  presence: true, uniqueness: true
+  validates :provider,  presence: true
 
   has_one_attached :image
 

--- a/backend/app/serializers/user_serializer.rb
+++ b/backend/app/serializers/user_serializer.rb
@@ -14,7 +14,6 @@
 #
 #  index_users_on_email               (email) UNIQUE
 #  index_users_on_email_and_provider  (email,provider) UNIQUE
-#  index_users_on_provider            (provider) UNIQUE
 #
 class UserSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers

--- a/backend/db/migrate/20241208155834_remove_index_from_users.rb
+++ b/backend/db/migrate/20241208155834_remove_index_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveIndexFromUsers < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :users, :provider if index_exists?(:users, :provider)
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_04_150630) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_08_155834) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -127,7 +127,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_04_150630) do
     t.datetime "updated_at", null: false
     t.index ["email", "provider"], name: "index_users_on_email_and_provider", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["provider"], name: "index_users_on_provider", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
# 概要
usersテーブルの編集
# 再現手順
1. rails db:migrateを実行
2. usersテーブルのproviderカラムからユニークキーが削除
# 期待する動作
rails db:migrateを実行すると、usersテーブルのproviderカラムからユニークキーが削除されること