### PR TITLE
プロフィール更新の修正

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -38,7 +38,7 @@ class Api::V1::UsersController < ApplicationController
 
   def update
     if @current_user.update(user_params)
-      head :ok
+      render json: @current_user, status: :ok
     else
       render json: { error: 'プロフィール編集に失敗しました' }, status: :unprocessable_entity
     end

--- a/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -87,8 +87,25 @@ const authOptions: NextAuthOptions = {
         return false
       }
     },
-    async jwt({ token, user }: { token: JWT; user: User }) {
-      if (user) {
+    async jwt({
+      token,
+      user,
+      trigger,
+      session,
+    }: {
+      token: JWT
+      user: User
+      trigger?: string
+      session?: { name: string; bio: string; image: string }
+    }) {
+      if (trigger === 'update' && session) {
+        token = {
+          ...token,
+          name: session.name,
+          bio: session.bio,
+          image: session.image,
+        }
+      } else if (user) {
         token = {
           ...token,
           ...user,


### PR DESCRIPTION
# 概要
プロフィール更新の修正
# 再現手順
1. Top詳細画面(`http://localhost:3001`/)に遷移
2. マイページ画面(`http://localhost:3001/my-page/:id`)に遷移
3. 「プロフィール編集」ボタンをクリック
4. マイページ編集画面(`http://localhost:3001/my-page/:id:edit`)に遷移
5. 画像、名前を変更
6. 「保存」ボタンをクリック
7. マイページ画面(`http://localhost:3001/my-page/:id`)に遷移
8. ヘッダーのアバターの画像が更新されている
9. プロフィール編集」ボタンをクリック
10.マイページ編集画面(`http://localhost:3001/my-page/:id:edit`)に遷移
11. マイページの画像、名前が更新後の値に設定されている
# 期待する動作
Top詳細画面(`http://localhost:3001`/)に遷移し、マイページ画面(`http://localhost:3001/my-page/:id`)に遷移し、「プロフィール編集」ボタンをクリックすると、マイページ編集画面(`http://localhost:3001/my-page/:id:edit`)に遷移し、画像、名前を変更し、「保存」ボタンをクリックするとマイページ画面(`http://localhost:3001/my-page/:id`)に遷移し、ヘッダーのアバターの画像が更新されていて、プロフィール編集」ボタンをクリックして、マイページ編集画面(`http://localhost:3001/my-page/:id:edit`)に遷移し、マイページの画像、名前が更新後の値に設定されていること。
# 動作環境
ログイン済であること