### PR TITLE
お知らせ機能の修正

### DIFF
--- a/backend/app/controllers/api/v1/notifications_controller.rb
+++ b/backend/app/controllers/api/v1/notifications_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::NotificationsController < ApplicationController
   before_action :authenticate, only: [:index, :update]
 
   def index
-    notifications = @current_user.notifications.includes(:notified_by)
+    notifications = @current_user.notifications.includes(:notified_by).order(created_at: :desc)
     render json: notifications, status: :ok
   end
 

--- a/backend/app/models/notification.rb
+++ b/backend/app/models/notification.rb
@@ -31,8 +31,10 @@ class Notification < ApplicationRecord
   enum :notification_type, { new_comment: 0, new_like: 1, new_follower: 2 }
 
   def self.create_notification(post = nil, user, notified_by, notification_type)
-    # 同一ユーザーの場合は通知を作成しない
-    return if user == notified_by
+    # 同一ユーザー、コメント以外の登録済の通知の場合は通知を作成しない
+    return if user == notified_by ||
+              (notification_type != :new_comment &&
+               exists?(post:, user:, notified_by:, notification_type:))
 
     create(post:, user:, notified_by:, notification_type:, read: false)
   end

--- a/backend/app/models/relationship.rb
+++ b/backend/app/models/relationship.rb
@@ -27,6 +27,6 @@ class Relationship < ApplicationRecord
   private
 
   def create_notification
-    Notification.create_notification(nil, follower, followed, :new_follower)
+    Notification.create_notification(nil, followed, follower, :new_follower)
   end
 end

--- a/frontend/src/app/notifications/page.tsx
+++ b/frontend/src/app/notifications/page.tsx
@@ -59,8 +59,8 @@ const Notifications = () => {
   const notifications: Notification[] = camelcaseKeys(data)
 
   return (
-    <List>
-      {notifications ? (
+    <List sx={{ py: 0 }}>
+      {notifications.length > 0 ? (
         notifications.map((notification) => (
           <Box
             key={notification.id}
@@ -70,7 +70,7 @@ const Notifications = () => {
           >
             <ListItem
               alignItems="flex-start"
-              sx={{ width: '100%' }}
+              sx={{ width: '100%', py: 0 }}
               onClick={() => {
                 if (!notification.read) {
                   handleSetNotificationRead(notification.id)
@@ -98,7 +98,7 @@ const Notifications = () => {
                       variant="body2"
                       sx={{
                         overflowWrap: 'break-word',
-                        mb: 0.2,
+                        mb: 0.5,
                       }}
                     >
                       <Typography
@@ -111,7 +111,7 @@ const Notifications = () => {
                       さんが
                       {notification.notificationType === 'フォロー'
                         ? 'あなたをフォローしました。'
-                        : `あなたを投稿に${notification.notificationType}しました。`}
+                        : `あなたの投稿に${notification.notificationType}しました。`}
                     </Typography>
                   }
                   secondary={


### PR DESCRIPTION
# 概要
お知らせ機能の修正
# 再現手順
お知らせがない場合
1. お知らせ画面(`http://localhost:3001/notifications`)に遷移
2. お知らせがない場合、「お知らせが見つかりませんでした。」と表示される

フォロー通知
1. Top詳細画面(`http://localhost:3001`/)に遷移
2. 投稿のユーザーをクリック
3. マイページに(`http://localhost:3001/my-page/:id`)遷移
4. ユーザーをフォローする
5. フォローされたユーザーにお知らせが表示される

同じ通知
1. Top詳細画面(`http://localhost:3001`/)に遷移
2. 投稿のいいねを複数回クリック
3. 投稿したユーザーのお知らせには1件だけ表示される
4. 投稿のユーザーをクリック
5. マイページに(`http://localhost:3001/my-page/:id`)遷移
6. ユーザーを複数回フォローする
7. フォローされたユーザーのお知らせには1件だけ表示される
8. Top詳細画面(`http://localhost:3001`/)に遷移
9. コメントをクリック
10. コメント一覧画面(`http://localhost:3001`/posts/:id/comments)に遷移
11. コメントを複数件送信する
12. 投稿したユーザーのお知らせにはコメントの件数表示される

# 期待する動作
お知らせがない場合
お知らせ画面(`http://localhost:3001/notifications`)に遷移し、お知らせがない場合、「お知らせが見つかりませんでした。」と表示されること。

フォロー通知
Top詳細画面(`http://localhost:3001`/)に遷移し、投稿のユーザーをクリックし、マイページに(`http://localhost:3001/my-page/:id`)遷移し、ユーザーをフォローすると、フォローされたユーザーにお知らせが表示されること。

同じ通知
Top詳細画面(`http://localhost:3001`/)に遷移し、投稿のいいねを複数回クリックすると、投稿したユーザーのお知らせには1件だけ表示される

投稿のユーザーをクリックし、マイページに(`http://localhost:3001/my-page/:id`)遷移し、ユーザーを複数回フォローすると、フォローされたユーザーのお知らせには1件だけ表示されること。

Top詳細画面(`http://localhost:3001`/)に遷移し、コメントをクリックすると、コメント一覧画面(`http://localhost:3001`/posts/:id/comments)に遷移し、コメントを複数件送信すると、投稿したユーザーのお知らせにはコメントの件数表示されること。

# 動作環境
ログイン済であること
