### PR TITLE
マイページへの画面遷移追加

### DIFF
--- a/frontend/src/app/posts/[id]/comments/page.tsx
+++ b/frontend/src/app/posts/[id]/comments/page.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material'
 import axios from 'axios'
 import camelcaseKeys from 'camelcase-keys'
+import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { useForm, Controller } from 'react-hook-form'
@@ -88,9 +89,11 @@ const Comments = () => {
         {comments.map((comment) => (
           <List key={comment.id} sx={{ p: 0, m: 0 }}>
             <ListItem alignItems="flex-start" sx={{ width: '100%', pl: 0 }}>
-              <ListItemAvatar>
-                <Avatar alt={comment.user.name} src={comment.user.image} />
-              </ListItemAvatar>
+              <Link href={`/my-page/${comment.user.id}`}>
+                <ListItemAvatar>
+                  <Avatar alt={comment.user.name} src={comment.user.image} />
+                </ListItemAvatar>
+              </Link>
               <ListItemText
                 primary={
                   <>

--- a/frontend/src/app/posts/[id]/page.tsx
+++ b/frontend/src/app/posts/[id]/page.tsx
@@ -174,11 +174,13 @@ const PostDetail = () => {
               }}
             >
               <Box sx={{ display: 'flex', mb: 2 }}>
-                <Avatar
-                  src={post.user.image}
-                  alt={post.user.name}
-                  sx={{ mr: 1.5 }}
-                />
+                <Link href={`/my-page/${post.user.id}`}>
+                  <Avatar
+                    src={post.user.image}
+                    alt={post.user.name}
+                    sx={{ mr: 1.5 }}
+                  />
+                </Link>
                 <Box>
                   <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
                     {post.user.name}


### PR DESCRIPTION
# 概要
マイページへの画面遷移追加
# 再現手順
投稿詳細画面遷移追加
1. Top詳細画面(`http://localhost:3001/`)に遷移
2. 投稿をクリック
3. 投稿詳細画面(`http://localhost:3001/posts/:id`)に遷移
4. ユーザーアイコンをクリック
5. マイページ(`http://localhost:3001/my-page/:id`)に遷移

コメント画面遷移追加
1. Top詳細画面(`http://localhost:3001/`)に遷移
2. 投稿のコメントをクリック
3. コメント画面(`http://localhost:3001/posts/:id/comments`)に遷移
4. ユーザーアイコンをクリック
5. マイページ(`http://localhost:3001/my-page/:id`)に遷移
# 期待する動作
投稿詳細画面遷移追加
Top詳細画面(`http://localhost:3001/`)に遷移し、投稿をクリックすると、投稿詳細画面(`http://localhost:3001/posts/:id`)に遷移し、ユーザーアイコンをクリックすると、マイページ(`http://localhost:3001/my-page/:id`)に遷移すること。

コメント画面遷移追加
Top詳細画面(`http://localhost:3001/`)に遷移し、投稿のコメントをクリックすると、コメント画面(`http://localhost:3001/posts/:id/comments`)に遷移し、ユーザーアイコンをクリックすると、マイページ(`http://localhost:3001/my-page/:id`)に遷移すること。
# 動作環境
ログイン済であること。