### PR TITLE
商品画像の縦横比変更

### DIFF
--- a/frontend/src/app/components/ProductCard.tsx
+++ b/frontend/src/app/components/ProductCard.tsx
@@ -31,7 +31,7 @@ const ProductCard = (props: ProductCardProps) => {
               src={props.image}
               alt=""
               fill
-              style={{ width: '100%', height: '100%' }}
+              style={{ width: '100%', height: '100%', objectFit: 'contain' }}
               sizes="(max-width: 600px) 50vw, (max-width: 1200px) 33vw, 25vw"
             />
           )}

--- a/frontend/src/app/product/[id]/page.tsx
+++ b/frontend/src/app/product/[id]/page.tsx
@@ -48,14 +48,16 @@ const ProductDetail = () => {
           px: 0,
         }}
       >
-        <Box sx={{ width: '100%', aspectRatio: '1 / 0.7', mb: 3 }}>
-          <Image
-            src={product.image}
-            alt={product.name}
-            width={300}
-            height={300}
-            style={{ width: '100%', height: '100%' }}
-          />
+        <Box sx={{ width: '100%', aspectRatio: '1 / 1', mb: 3 }}>
+          {product.image && (
+            <Image
+              src={product.image || ''}
+              alt={product.name}
+              width={300}
+              height={300}
+              style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+            />
+          )}
         </Box>
         <Box sx={{ width: '94%', m: '0 auto' }}>
           <Typography variant="body2" sx={{ fontWeight: 'bold', mb: 0.7 }}>


### PR DESCRIPTION
# 概要
商品画像の縦横比変更
# 再現手順
1. Top詳細画面(`http://localhost:3001/`)に遷移
2. 投稿をクリック
3. 投稿詳細画面(`http://localhost:3001/posts/:id`)に遷移
4. おすすめ商品の画像のアスペクト比を保たれて表示される
5. 商品をクリック
6. 商品詳細画面(`http://localhost:3001/products/:id`)に遷移
7. 商品の画像のアスペクト比を保たれて表示される
# 期待する動作
Top詳細画面(`http://localhost:3001/`)に遷移し、投稿をクリックすると、投稿詳細画面(`http://localhost:3001/posts/:id`)に遷移し、おすすめ商品の画像のアスペクト比を保たれて表示されること。
商品をクリックし、商品詳細画面(`http://localhost:3001/products/:id`)に遷移すると、商品の画像のアスペクト比を保たれて表示されること。