### PR TITLE
フォロー中、フォロワー一覧画面の追加

### DIFF
--- a/backend/app/controllers/api/v1/relationships_controller.rb
+++ b/backend/app/controllers/api/v1/relationships_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::RelationshipsController < ApplicationController
   before_action :authenticate, only: [:create, :destroy]
-  before_action :set_user, only: [:create, :destroy]
+  before_action :set_user, only: [:create, :destroy, :following, :followers]
 
   def create
     if @current_user.follow(@user)
@@ -18,9 +18,19 @@ class Api::V1::RelationshipsController < ApplicationController
     end
   end
 
+  def following
+    following = @user.followings
+    render json: following, each_serializer: RelationshipSerializer, status: :ok
+  end
+
+  def followers
+    followers = @user.followers
+    render json: followers, each_serializer: RelationshipSerializer, status: :ok
+  end
+
   private
 
   def set_user
-    @user = User.find(params[:user_id])
+    @user = User.find(params[:id])
   end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -27,6 +27,8 @@ class User < ApplicationRecord
                                    foreign_key: 'followed_id',
                                    dependent: :destroy,
                                    inverse_of: :followed
+  has_many :followings, through: :active_relationships, source: :followed
+  has_many :followers, through: :passive_relationships, source: :follower
   has_many :notifications, dependent: :destroy
 
   validates :name,      presence: true

--- a/backend/app/serializers/relationship_serializer.rb
+++ b/backend/app/serializers/relationship_serializer.rb
@@ -1,0 +1,9 @@
+class RelationshipSerializer < ApplicationSerializer
+  include Rails.application.routes.url_helpers
+
+  attributes :id, :image, :name, :bio
+
+  def image
+    object.image.attached? ? rails_blob_url(object.image, host: UrlHost.host) : nil
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,8 +7,10 @@ Rails.application.routes.draw do
       post "auth/:provider/callback", to: "users#create"
       get "api_check", to: "api_check#index"
       resources :users, only: [:show, :update] do
-        resource :relationships, only: [:create, :destroy]
         member do
+          resource :relationships, only: [:create, :destroy]
+          get "following" , to: "relationships#following"
+          get "followers" , to: "relationships#followers"
           get "user_posts", to: "posts#user_posts"
           get "like_posts", to: "posts#like_posts"
         end

--- a/frontend/src/app/components/FollowList.tsx
+++ b/frontend/src/app/components/FollowList.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import {
+  Typography,
+  Avatar,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Divider,
+  Box,
+} from '@mui/material'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import useSWR from 'swr'
+import Error from '@/app/components/Error'
+import Loading from '@/app/components/Loading'
+import NavigationHeader from '@/app/components/NavigationHeader'
+import { fetcher } from '@/utils/fetcher'
+import { getFollowersUrl, getFollowingUrl } from '@/utils/urls'
+
+type Follow = {
+  id: string
+  image: string
+  name: string
+  bio: string
+}
+
+type FollowListProps = {
+  type: 'following' | 'followers'
+}
+
+const FollowList = ({ type }: FollowListProps) => {
+  const { id } = useParams<{ id: string }>()
+  const { data, error } = useSWR<Follow[]>(
+    type === 'following' ? getFollowingUrl(id) : getFollowersUrl(id),
+    fetcher,
+  )
+
+  if (error) return <Error />
+  if (!data) return <Loading />
+  return (
+    <>
+      <NavigationHeader
+        title={type === 'following' ? 'フォロー中' : 'フォロワー'}
+      />
+      <List sx={{ py: 0 }}>
+        {data.length > 0 ? (
+          data.map((following) => (
+            <Box key={following.id}>
+              <Link href={`/my-page/${following.id}`}>
+                <ListItem alignItems="flex-start" sx={{ width: '100%', py: 0 }}>
+                  <ListItemAvatar>
+                    <Avatar alt={following.name} src={following.image} />
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          overflowWrap: 'break-word',
+                          mb: 0.5,
+                        }}
+                      >
+                        {following.name}
+                      </Typography>
+                    }
+                    secondary={
+                      <Typography sx={{ fontSize: 13 }}>
+                        {following.bio}
+                      </Typography>
+                    }
+                  />
+                </ListItem>
+              </Link>
+              <Divider
+                variant="inset"
+                component="li"
+                sx={{ m: 0, width: '100%' }}
+              />
+            </Box>
+          ))
+        ) : (
+          <Typography variant="body2" sx={{ mt: 2, textAlign: 'center' }}>
+            {type === 'following' ? 'フォロー中のユーザー' : 'フォロワー'}
+            は見つかりませんでした。
+          </Typography>
+        )}
+      </List>
+    </>
+  )
+}
+
+export default FollowList

--- a/frontend/src/app/components/Header.tsx
+++ b/frontend/src/app/components/Header.tsx
@@ -46,7 +46,7 @@ const Header = () => {
     /\/posts\/\d+$/.test(pathname) ||
     /\/posts\/\d+\/(comments|edit)$/.test(pathname) ||
     /\/product\/\d+$/.test(pathname) ||
-    /\/my-page\/\d+\/edit$/.test(pathname)
+    /\/my-page\/\d+\/(edit|following|followers)$/.test(pathname)
 
   if (isPathMatch || hiddenPathnames.includes(pathname)) return <></>
 

--- a/frontend/src/app/my-page/[id]/followers/page.tsx
+++ b/frontend/src/app/my-page/[id]/followers/page.tsx
@@ -1,0 +1,7 @@
+import FollowList from '@/app/components/FollowList'
+
+const Followers = () => {
+  return <FollowList type="followers" />
+}
+
+export default Followers

--- a/frontend/src/app/my-page/[id]/following/page.tsx
+++ b/frontend/src/app/my-page/[id]/following/page.tsx
@@ -1,0 +1,7 @@
+import FollowList from '@/app/components/FollowList'
+
+const Following = () => {
+  return <FollowList type="following" />
+}
+
+export default Following

--- a/frontend/src/app/my-page/[id]/page.tsx
+++ b/frontend/src/app/my-page/[id]/page.tsx
@@ -101,38 +101,42 @@ const MyPage = () => {
         </Typography>
       </Box>
       <Box sx={{ display: 'flex', mb: 2 }}>
-        <Box>
-          <Typography
-            variant="body2"
-            component="span"
-            sx={{ fontWeight: 'bold', mr: 0.3 }}
-          >
-            {user.followedCount}
-          </Typography>
-          <Typography
-            variant="body2"
-            component="span"
-            sx={{ color: '#666666', mr: 1 }}
-          >
-            フォロー中
-          </Typography>
-        </Box>
-        <Box>
-          <Typography
-            variant="body2"
-            component="span"
-            sx={{ fontWeight: 'bold', mr: 0.3 }}
-          >
-            {user.followerCount}
-          </Typography>
-          <Typography
-            variant="body2"
-            component="span"
-            sx={{ color: '#666666' }}
-          >
-            フォロワー
-          </Typography>
-        </Box>
+        <Link href={`/my-page/${id}/following`}>
+          <Box>
+            <Typography
+              variant="body2"
+              component="span"
+              sx={{ fontWeight: 'bold', mr: 0.3 }}
+            >
+              {user.followedCount}
+            </Typography>
+            <Typography
+              variant="body2"
+              component="span"
+              sx={{ color: '#666666', mr: 1 }}
+            >
+              フォロー中
+            </Typography>
+          </Box>
+        </Link>
+        <Link href={`/my-page/${id}/followers`}>
+          <Box>
+            <Typography
+              variant="body2"
+              component="span"
+              sx={{ fontWeight: 'bold', mr: 0.3 }}
+            >
+              {user.followerCount}
+            </Typography>
+            <Typography
+              variant="body2"
+              component="span"
+              sx={{ color: '#666666' }}
+            >
+              フォロワー
+            </Typography>
+          </Box>
+        </Link>
       </Box>
       <Typography variant="body2" sx={{ overflowWrap: 'break-word', mb: 3 }}>
         {data.bio}

--- a/frontend/src/utils/urls.ts
+++ b/frontend/src/utils/urls.ts
@@ -73,3 +73,11 @@ export const getNotificationUrl = `${HOST_API_URL}/notifications`
 // お知らせ更新URL（PATCH）
 export const updateNotificationUrl = (id: string) =>
   `${HOST_API_URL}/notifications/${id}`
+
+// フォロワー取得URL（GET）
+export const getFollowersUrl = (id: string) =>
+  `${HOST_API_URL}/users/${id}/followers`
+
+// フォロー中取得URL（GET）
+export const getFollowingUrl = (id: string) =>
+  `${HOST_API_URL}/users/${id}/following`


### PR DESCRIPTION
# 概要
フォロー中、フォロワー一覧画面の追加
# 再現手順
1. マイページ(`http://localhost:3001/my-page/:id`)に遷移
2. フォロー中をクリック
3. フォロー中一覧画面(`http://localhost:3001/my-page/:id/followings`)に遷移
4. マイページ(`http://localhost:3001/my-page/:id`)に遷移
5. フォロワーをクリック
6. フォロワー一覧画面(`http://localhost:3001/my-page/:id/followers`)に遷移
# 期待する動作
マイページ(`http://localhost:3001/my-page/:id`)に遷移し、フォロー中をクリックすると、フォロー中一覧画面(`http://localhost:3001/my-page/:id/followings`)に遷移すること。
マイページ(`http://localhost:3001/my-page/:id`)に遷移し、フォロワーをクリックすつと、フォロワー一覧画面(`http://localhost:3001/my-page/:id/followers`)に遷移すること。