### PR TITLE
いいね、フォロー連打での複数登録の修正

### DIFF
--- a/frontend/src/app/components/PostActions.tsx
+++ b/frontend/src/app/components/PostActions.tsx
@@ -6,7 +6,7 @@ import axios from 'axios'
 import { motion } from 'framer-motion'
 import Link from 'next/link'
 import { useSession } from 'next-auth/react'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import {
   LineShareButton,
   LineIcon,
@@ -31,8 +31,12 @@ const PostActions = (props: PostActionsProps) => {
   const [isLike, setIsLike] = useState(props.isLiked)
   const [likeCount, setLikeCount] = useState(props.likeCount)
   const shareUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/posts/${props.id}`
+  const isLoading = useRef<boolean>(false)
 
   const handleLike = async () => {
+    if (isLoading.current) return
+    isLoading.current = true
+
     const method = isLike ? 'delete' : 'post'
     try {
       const res = await axios({
@@ -46,6 +50,8 @@ const PostActions = (props: PostActionsProps) => {
       setLikeCount(res.data)
     } catch (err) {
       console.log(err)
+    } finally {
+      isLoading.current = false
     }
   }
 

--- a/frontend/src/app/my-page/[id]/page.tsx
+++ b/frontend/src/app/my-page/[id]/page.tsx
@@ -14,7 +14,7 @@ import camelcaseKeys from 'camelcase-keys'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import useSWR, { mutate } from 'swr'
 import MyPagePosts from '../../components/MyPagePosts'
 import Error from '@/app/components/Error'
@@ -62,11 +62,15 @@ const MyPage = () => {
   const [value, setValue] = useState(0)
   const { id } = useParams<{ id: string }>()
   const { data: session } = useSession()
+  const isLoading = useRef(false)
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue)
   }
 
   const handleFollow = async () => {
+    if (isLoading.current) return
+    isLoading.current = true
+
     const method = user.isFollowing ? 'delete' : 'post'
     try {
       await axios({
@@ -76,9 +80,11 @@ const MyPage = () => {
           'auth-token': session?.user.token,
         },
       })
-      mutate([getUserByIdUrl(id), session?.user?.token])
+      await mutate([getUserByIdUrl(id), session?.user?.token])
     } catch (err) {
       console.log(err)
+    } finally {
+      isLoading.current = false
     }
   }
 


### PR DESCRIPTION
# 概要
いいね、フォロー連打での複数登録の修正
# 再現手順
1. Top詳細画面(`http://localhost:3001/`)に遷移
2. 投稿のいいねを連打
3. 複数登録されない
4. 投稿のアバターをクリック
5. マイページ(`http://localhost:3001/my-page/:id`)に遷移
6. フォローボタンを連打
7. 複数登録されない
# 期待する動作
Top詳細画面(`http://localhost:3001/`)に遷移し、投稿のいいねを連打しても、複数登録されないこと。
投稿のアバターをクリックし、マイページ(`http://localhost:3001/my-page/:id`)に遷移し、フォローボタンを連打しても、複数登録されないこと。
# 動作環境
ログイン済であること。