### PR TITLE
フォロー、フォロワー一覧画面デザイン修正

### DIFF
--- a/frontend/src/app/components/FollowList.tsx
+++ b/frontend/src/app/components/FollowList.tsx
@@ -49,17 +49,22 @@ const FollowList = ({ type }: FollowListProps) => {
           data.map((following) => (
             <Box key={following.id}>
               <Link href={`/my-page/${following.id}`}>
-                <ListItem alignItems="flex-start" sx={{ width: '100%', py: 0 }}>
+                <ListItem
+                  alignItems="flex-start"
+                  sx={{
+                    width: '100%',
+                  }}
+                >
                   <ListItemAvatar>
                     <Avatar alt={following.name} src={following.image} />
                   </ListItemAvatar>
                   <ListItemText
                     primary={
                       <Typography
-                        variant="body2"
                         sx={{
                           overflowWrap: 'break-word',
-                          mb: 0.5,
+                          fontSize: 13.5,
+                          fontWeight: 'bold',
                         }}
                       >
                         {following.name}


### PR DESCRIPTION
# 概要
フォロー、フォロワー一覧画面デザイン修正
# 再現手順
1. マイページ画面(`htttp://localhost:3001/my-page/:id`)に遷移
2. フォローをクリック
3. フォロー一覧画面(`htttp://localhost:3001/my-page/:id/following`)に遷移
4. デザインが修正されている
5. 戻るボタンをクリック
6. マイページ画面(`htttp://localhost:3001/my-page/:id`)に遷移
7. フォロワーをクリック
8. フォロワー一覧画面(`htttp://localhost:3001/my-page/:id/followers`)に遷移
9. デザインが修正されている
# 期待する動作
マイページ画面(`htttp://localhost:3001/my-page/:id`)に遷移し、フォローをクリックすると、フォロー一覧画面(`htttp://localhost:3001/my-page/:id/following`)に遷移し、デザインが修正されていること。
戻るボタンをクリックし、マイページ画面(`htttp://localhost:3001/my-page/:id`)に遷移し、フォロワーをクリックすると、フォロワー一覧画面(`htttp://localhost:3001/my-page/:id/followers`)に遷移し、デザインが修正されていること。