### PR TITLE
お知らせ画面の修正

### DIFF
--- a/frontend/src/app/notifications/page.tsx
+++ b/frontend/src/app/notifications/page.tsx
@@ -59,7 +59,7 @@ const Notifications = () => {
   const notifications: Notification[] = camelcaseKeys(data)
 
   return (
-    <List sx={{ py: 0 }}>
+    <List sx={{ pt: 0, pb: '57px' }}>
       {notifications.length > 0 ? (
         notifications.map((notification) => (
           <Box


### PR DESCRIPTION
# 概要
お知らせ画面の修正
# 再現手順
1. お知らせ画面(`http://localhost:3001//notifications`)に遷移
2. お知らせの一番したの要素が表示されている
# 期待する動作
お知らせ画面(`http://localhost:3001//notifications`)に遷移すると、お知らせの一番したの要素が表示されていること。
# 動作環境
ログイン済であること。