### PR TITLE
通知の表示時間短縮

### DIFF
--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -60,7 +60,7 @@ const NotificationProvider = ({ children }: NotificationProviderProps) => {
           <Snackbar
             anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
             open={open}
-            autoHideDuration={8000}
+            autoHideDuration={2000}
             onClose={handleClose}
             sx={{
               left: { lg: '61%' },


### PR DESCRIPTION
# 概要
通知の表示時間短縮
# 再現手順
1. Topページ(`http://localhost:3001`)に遷移
2. ログインボタンをクリック
3. ログイン成功後「ログインが成功しました」の通知が2秒間表示される
# 期待する動作
Topページ(`http://localhost:3001`)に遷移し、ログインボタンをクリックすると、ログイン成功後「ログインが成功しました」の通知が2秒間表示されること。